### PR TITLE
fix: the parameter passing bug when connecting to mcp

### DIFF
--- a/packages/derisk-core/src/derisk/agent/resource/tool/pack.py
+++ b/packages/derisk-core/src/derisk/agent/resource/tool/pack.py
@@ -407,12 +407,13 @@ class MCPToolPack(ToolPack):
             del arguments[arg_name]
 
         # Rebuild derisk mcp call param
+        server = self.tool_server_map[tl.name]
         return {
             "mcp_name": self.name,
             "server": self.tool_server_map[tl.name],
             "args": arguments,
             "tool_name": tl.name,
-            "headers": self._headers,
+            "headers": self.server_headers_map[server],
         }
 
     # async def get_mcp_tool_list(self, server: str, headers: Optional[dict] = None, server_ssl_verify: Optional[Any] = None):
@@ -491,7 +492,7 @@ class MCPToolPack(ToolPack):
                 self._headers["x-mcp-hash-key"] = str(uuid.uuid4())
                 result = await get_mcp_tool_list(
                     self.name, server,
-                    headers=self._headers,
+                    headers=self.server_headers_map[server],
                     allow_tools=self._allow_tools
                 )
                 for tool in result.tools:
@@ -506,7 +507,7 @@ class MCPToolPack(ToolPack):
                         tool_name=tool_name,
                         server=server,
                         trace_id=trace_id,
-                        headers=self._headers,
+                        headers=self.server_headers_map[server],
                     )
 
                     self.add_command(


### PR DESCRIPTION
# Description

Fixed the issue that when connecting to MCP, the parameters passed were incorrect, resulting in the default_header not being passed in.

# How Has This Been Tested?

Already tested

# Snapshots:

Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
