### PR TITLE
feat: add npm package for easy installation

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,56 @@
+# OpenDerisk NPM Package
+
+NPM wrapper for OpenDeRisk AI-Native Risk Intelligence Systems.
+
+## Installation
+
+```bash
+npm install -g openderisk
+```
+
+Or use with npx (no installation):
+```bash
+npx openderisk
+```
+
+## Usage
+
+### CLI
+
+```bash
+# Show help
+openderisk --help
+
+# Start OpenDerisk
+openderisk
+
+# Start server
+openderisk-server
+
+# Update to latest version
+openderisk --update
+```
+
+### Requirements
+
+- Node.js >= 16.0.0
+- Python >= 3.10 (will be installed automatically)
+- Git
+
+## What is OpenDerisk?
+
+OpenDeRisk is an AI-Native Risk Intelligence System that provides:
+
+- **DeepResearch RCA**: Quickly locate root causes through analysis of logs, traces, and code
+- **Visualized Evidence Chain**: Full visualization of diagnostic processes
+- **Multi-Agent Collaboration**: SRE-Agent, Code-Agent, ReportAgent, Vis-Agent, and Data-Agent
+- **Open Architecture**: Completely open-source framework
+
+## Documentation
+
+- [GitHub Repository](https://github.com/derisk-ai/OpenDerisk)
+- [DeepWiki Documentation](https://deepwiki.com/derisk-ai/OpenDerisk)
+
+## License
+
+MIT

--- a/npm/bin/openderisk-server.js
+++ b/npm/bin/openderisk-server.js
@@ -38,7 +38,7 @@ function main() {
   const uvPath = path.join(os.homedir(), '.local/bin/uv');
   const pythonCmd = fs.existsSync(uvPath) ? uvPath : 'uv';
 
-  const child = spawn(pythonCmd, ['run', 'python', '-m', 'derisk.serve', ...process.argv.slice(2)], {
+  const child = spawn(pythonCmd, ['run', 'derisk', 'start', 'webserver', ...process.argv.slice(2)], {
     cwd: INSTALL_DIR,
     stdio: 'inherit',
     env: process.env

--- a/npm/bin/openderisk-server.js
+++ b/npm/bin/openderisk-server.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+/**
+ * OpenDerisk Server Launcher
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const INSTALL_DIR = process.env.OPENDERISK_INSTALL_DIR || path.join(os.homedir(), '.openderisk');
+
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  blue: '\x1b[34m'
+};
+
+function log(message) {
+  console.log(`${colors.blue}[OpenDerisk Server]${colors.reset} ${message}`);
+}
+
+function error(message) {
+  console.error(`${colors.red}[Error]${colors.reset} ${message}`);
+  process.exit(1);
+}
+
+function main() {
+  if (!fs.existsSync(INSTALL_DIR)) {
+    error('OpenDerisk not installed. Please run: npm install -g openderisk');
+  }
+
+  log('Starting OpenDerisk Server...');
+  log(`Config: ${path.join(INSTALL_DIR, 'configs/derisk-proxy-aliyun.toml')}`);
+
+  const uvPath = path.join(os.homedir(), '.local/bin/uv');
+  const pythonCmd = fs.existsSync(uvPath) ? uvPath : 'uv';
+
+  const child = spawn(pythonCmd, ['run', 'python', '-m', 'derisk.serve', ...process.argv.slice(2)], {
+    cwd: INSTALL_DIR,
+    stdio: 'inherit',
+    env: process.env
+  });
+
+  child.on('error', (err) => {
+    error(`Failed to start server: ${err.message}`);
+  });
+
+  child.on('exit', (code) => {
+    process.exit(code || 0);
+  });
+}
+
+main();

--- a/npm/bin/openderisk.js
+++ b/npm/bin/openderisk.js
@@ -134,7 +134,7 @@ function runOpenDerisk(args) {
   const uvPath = path.join(os.homedir(), '.local/bin/uv');
   const pythonCmd = fs.existsSync(uvPath) ? uvPath : 'uv';
   
-  const child = spawn(pythonCmd, ['run', 'python', '-m', 'derisk', ...args], {
+  const child = spawn(pythonCmd, ['run', 'derisk', ...args], {
     cwd: INSTALL_DIR,
     stdio: 'inherit',
     env: process.env

--- a/npm/bin/openderisk.js
+++ b/npm/bin/openderisk.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * OpenDerisk CLI Launcher
+ * 
+ * This script wraps the Python-based OpenDerisk tool,
+ * handling installation and execution automatically.
+ */
+
+const { spawn, execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const INSTALL_DIR = process.env.OPENDERISK_INSTALL_DIR || path.join(os.homedir(), '.openderisk');
+const REPO_URL = 'https://github.com/derisk-ai/OpenDerisk.git';
+
+// Colors for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m'
+};
+
+function log(message) {
+  console.log(`${colors.blue}[OpenDerisk]${colors.reset} ${message}`);
+}
+
+function warn(message) {
+  console.log(`${colors.yellow}[Warning]${colors.reset} ${message}`);
+}
+
+function error(message) {
+  console.error(`${colors.red}[Error]${colors.reset} ${message}`);
+  process.exit(1);
+}
+
+function success(message) {
+  console.log(`${colors.green}[Success]${colors.reset} ${message}`);
+}
+
+function commandExists(command) {
+  try {
+    execSync(`which ${command}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureUv() {
+  if (commandExists('uv')) {
+    log('uv is already installed');
+    return;
+  }
+
+  log('Installing uv (Python package manager)...');
+  try {
+    execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', { 
+      stdio: 'inherit',
+      shell: true 
+    });
+    success('uv installed successfully');
+  } catch (err) {
+    error(`Failed to install uv: ${err.message}`);
+  }
+}
+
+function ensureRepo() {
+  if (fs.existsSync(path.join(INSTALL_DIR, '.git'))) {
+    log('OpenDerisk already installed, updating...');
+    try {
+      execSync('git pull origin main', { 
+        cwd: INSTALL_DIR, 
+        stdio: 'pipe' 
+      });
+    } catch (err) {
+      warn('Failed to update, using existing version');
+    }
+    return;
+  }
+
+  log('Installing OpenDerisk...');
+  const parentDir = path.dirname(INSTALL_DIR);
+  
+  if (!fs.existsSync(parentDir)) {
+    fs.mkdirSync(parentDir, { recursive: true });
+  }
+
+  try {
+    execSync(`git clone --depth 1 ${REPO_URL} "${INSTALL_DIR}"`, {
+      stdio: 'inherit'
+    });
+    success('OpenDerisk repository cloned');
+  } catch (err) {
+    error(`Failed to clone repository: ${err.message}`);
+  }
+}
+
+function installDeps() {
+  log('Installing Python dependencies...');
+  
+  const extras = [
+    'base',
+    'proxy_openai',
+    'rag',
+    'storage_chromadb',
+    'derisks',
+    'storage_oss2',
+    'client',
+    'ext_base'
+  ].map(e => `--extra "${e}"`).join(' ');
+
+  try {
+    execSync(`uv sync --all-packages --frozen ${extras}`, {
+      cwd: INSTALL_DIR,
+      stdio: 'inherit',
+      shell: true,
+      env: {
+        ...process.env,
+        PATH: `${path.join(os.homedir(), '.local/bin')}:${process.env.PATH}`
+      }
+    });
+    success('Dependencies installed');
+  } catch (err) {
+    error(`Failed to install dependencies: ${err.message}`);
+  }
+}
+
+function runOpenDerisk(args) {
+  const uvPath = path.join(os.homedir(), '.local/bin/uv');
+  const pythonCmd = fs.existsSync(uvPath) ? uvPath : 'uv';
+  
+  const child = spawn(pythonCmd, ['run', 'python', '-m', 'derisk', ...args], {
+    cwd: INSTALL_DIR,
+    stdio: 'inherit',
+    env: process.env
+  });
+
+  child.on('error', (err) => {
+    error(`Failed to start OpenDerisk: ${err.message}`);
+  });
+
+  child.on('exit', (code) => {
+    process.exit(code || 0);
+  });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  // Handle help
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(`
+${colors.cyan}OpenDerisk CLI${colors.reset}
+
+Usage: openderisk [options] [command]
+
+Options:
+  -h, --help     Show this help message
+  -v, --version  Show version information
+  --update       Update to latest version
+
+Commands:
+  server         Start OpenDerisk server
+  
+For more information: https://github.com/derisk-ai/OpenDerisk
+    `);
+    return;
+  }
+
+  // Handle version
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log('OpenDerisk v0.2.0');
+    return;
+  }
+
+  // Handle update
+  if (args.includes('--update')) {
+    ensureUv();
+    ensureRepo();
+    installDeps();
+    success('OpenDerisk updated successfully!');
+    return;
+  }
+
+  // First run setup
+  if (!fs.existsSync(INSTALL_DIR)) {
+    ensureUv();
+    ensureRepo();
+    installDeps();
+  }
+
+  // Run OpenDerisk
+  runOpenDerisk(args);
+}
+
+main();

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+module.exports = require('./bin/openderisk.js');

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "openderisk",
+  "version": "0.2.0",
+  "description": "OpenDeRisk AI-Native Risk Intelligence Systems — Your application system risk intelligent manager",
+  "main": "index.js",
+  "bin": {
+    "openderisk": "bin/openderisk.js",
+    "openderisk-server": "bin/openderisk-server.js"
+  },
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js",
+    "start": "node bin/openderisk.js",
+    "server": "node bin/openderisk-server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "openderisk",
+    "ai",
+    "risk-management",
+    "root-cause-analysis",
+    "sre",
+    "devops",
+    "monitoring",
+    "observability",
+    "multi-agent"
+  ],
+  "author": "HongjunYang <yhjun1026@gmail.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/derisk-ai/OpenDerisk",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/derisk-ai/OpenDerisk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/derisk-ai/OpenDerisk/issues"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "preferGlobal": true,
+  "files": [
+    "bin/",
+    "scripts/",
+    "README.md",
+    "LICENSE"
+  ]
+}

--- a/npm/scripts/postinstall.js
+++ b/npm/scripts/postinstall.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+/**
+ * Post-install script for OpenDerisk npm package
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const INSTALL_DIR = process.env.OPENDERISK_INSTALL_DIR || path.join(os.homedir(), '.openderisk');
+const REPO_URL = 'https://github.com/derisk-ai/OpenDerisk.git';
+
+const colors = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m'
+};
+
+function log(message) {
+  console.log(`${colors.cyan}[openderisk]${colors.reset} ${message}`);
+}
+
+function success(message) {
+  console.log(`${colors.green}[openderisk]${colors.reset} ${message}`);
+}
+
+function warn(message) {
+  console.log(`${colors.yellow}[openderisk]${colors.reset} ${message}`);
+}
+
+function commandExists(command) {
+  try {
+    execSync(`which ${command}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function installUv() {
+  if (commandExists('uv')) {
+    return;
+  }
+
+  log('Installing uv package manager...');
+  try {
+    execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', {
+      stdio: 'inherit',
+      shell: true
+    });
+    success('uv installed successfully');
+  } catch (err) {
+    warn('Failed to install uv automatically');
+    warn('Please install manually: https://github.com/astral-sh/uv');
+  }
+}
+
+function cloneRepo() {
+  if (fs.existsSync(path.join(INSTALL_DIR, '.git'))) {
+    log('OpenDerisk already exists, skipping clone');
+    return;
+  }
+
+  log('Cloning OpenDerisk repository...');
+  const parentDir = path.dirname(INSTALL_DIR);
+  
+  if (!fs.existsSync(parentDir)) {
+    fs.mkdirSync(parentDir, { recursive: true });
+  }
+
+  try {
+    execSync(`git clone --depth 1 ${REPO_URL} "${INSTALL_DIR}"`, {
+      stdio: 'inherit'
+    });
+    success('Repository cloned successfully');
+  } catch (err) {
+    warn('Failed to clone repository automatically');
+    warn(`You can manually clone: git clone ${REPO_URL} ${INSTALL_DIR}`);
+  }
+}
+
+function main() {
+  console.log('');
+  log('Setting up OpenDerisk...');
+  console.log('');
+
+  installUv();
+  cloneRepo();
+
+  console.log('');
+  success('Setup complete! 🎉');
+  console.log('');
+  console.log('Next steps:');
+  console.log('  1. Configure API keys in:');
+  console.log(`     ${path.join(INSTALL_DIR, 'configs/derisk-proxy-aliyun.toml')}`);
+  console.log('  2. Run: openderisk --help');
+  console.log('  3. Start server: openderisk-server');
+  console.log('');
+  console.log('Documentation: https://github.com/derisk-ai/OpenDerisk');
+  console.log('');
+}
+
+main();


### PR DESCRIPTION
## Description
Add npm package for easy installation via npm install -g.

## Features
- Add package.json with openderisk and openderisk-server binaries
- Create CLI wrapper scripts for Node.js
- Auto-install uv and clone repo on postinstall
- Support global installation via npm install -g
- Support npx usage without installation

## Files Added
- npm/package.json
- npm/bin/openderisk.js
- npm/bin/openderisk-server.js
- npm/scripts/postinstall.js
- npm/README.md
- npm/index.js