### PR TITLE
feat: add homebrew formula for easy macOS installation

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,34 @@
+name: Publish to Homebrew
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Homebrew Formula
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          URL="https://github.com/derisk-ai/OpenDerisk/archive/refs/tags/v${VERSION}.tar.gz"
+          SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          
+          sed -i "s/PLACEHOLDER_SHA256/${SHA256}/g" homebrew/openderisk.rb
+          sed -i "s|url \"https://github.com/derisk-ai/OpenDerisk/archive/refs/tags/v0.2.0.tar.gz\"|url \"${URL}\"|g" homebrew/openderisk.rb
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update homebrew formula for ${{ github.ref_name }}"
+          title: "Update Homebrew formula to ${{ github.ref_name }}"
+          body: |
+            Automated update of Homebrew formula for new release.
+            
+            - Updated URL to ${{ github.ref_name }}
+            - Updated SHA256 checksum
+          branch: update-homebrew-formula

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,77 @@
+# OpenDerisk Homebrew Tap
+
+Homebrew formula for OpenDeRisk AI-Native Risk Intelligence Systems.
+
+## Installation
+
+### Add the tap
+
+```bash
+brew tap derisk-ai/openderisk
+```
+
+Or install directly:
+
+```bash
+brew install derisk-ai/openderisk/openderisk
+```
+
+### Direct install (without tap)
+
+```bash
+brew install --cask https://raw.githubusercontent.com/derisk-ai/OpenDerisk/main/homebrew/openderisk.rb
+```
+
+## Usage
+
+```bash
+# Start CLI
+openderisk
+
+# Start server
+openderisk-server
+
+# Check version
+openderisk --version
+```
+
+## Requirements
+
+- macOS 11+ (Big Sur or later)
+- Apple Silicon or Intel Mac
+- Homebrew 3.0+
+
+## Uninstall
+
+```bash
+brew uninstall openderisk
+brew untap derisk-ai/openderisk
+```
+
+## Formula Details
+
+This formula:
+- Installs Python 3.10+ via Homebrew
+- Installs uv (Python package manager)
+- Sets up all Python dependencies
+- Creates `openderisk` and `openderisk-server` commands
+- Configures the application in `/opt/homebrew/opt/openderisk`
+
+## Troubleshooting
+
+### Reset installation
+
+```bash
+brew reinstall openderisk
+```
+
+### Check logs
+
+```bash
+brew services logs openderisk
+```
+
+## Documentation
+
+- [OpenDerisk GitHub](https://github.com/derisk-ai/OpenDerisk)
+- [Homebrew Documentation](https://docs.brew.sh/)

--- a/homebrew/openderisk.rb
+++ b/homebrew/openderisk.rb
@@ -1,0 +1,98 @@
+class Openderisk < Formula
+  desc "AI-Native Risk Intelligence Systems for application stability"
+  homepage "https://github.com/derisk-ai/OpenDerisk"
+  url "https://github.com/derisk-ai/OpenDerisk/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "PLACEHOLDER_SHA256"
+  license "MIT"
+
+  depends_on "python@3.10"
+  depends_on "git"
+  depends_on "uv"
+
+  resource "uv" do
+    url "https://github.com/astral-sh/uv/releases/download/0.5.0/uv-aarch64-apple-darwin.tar.gz"
+    sha256 "PLACEHOLDER_UV_SHA256"
+  end
+
+  def install
+    # Install uv if not present
+    uv_bin = buildpath/"uv"
+    resource("uv").stage do
+      bin.install "uv"
+      bin.install "uvx"
+    end
+
+    # Create wrapper scripts
+    (bin/"openderisk").write <<~EOS
+      #!/bin/bash
+      export PATH="#{bin}:${PATH}"
+      cd "#{libexec}" || exit 1
+      exec uv run python -m derisk "$@"
+    EOS
+
+    (bin/"openderisk-server").write <<~EOS
+      #!/bin/bash
+      export PATH="#{bin}:${PATH}"
+      cd "#{libexec}" || exit 1
+      exec uv run python -m derisk.serve "$@"
+    EOS
+
+    chmod 0755, bin/"openderisk"
+    chmod 0755, bin/"openderisk-server"
+
+    # Install Python dependencies
+    system "uv", "sync", "--all-packages", "--frozen",
+           "--extra", "base",
+           "--extra", "proxy_openai",
+           "--extra", "rag",
+           "--extra", "storage_chromadb",
+           "--extra", "derisks",
+           "--extra", "storage_oss2",
+           "--extra", "client",
+           "--extra", "ext_base"
+
+    # Copy project files
+    libexec.install Dir["*"]
+
+    # Create config directory
+    (etc/"openderisk").mkpath
+  end
+
+  def post_install
+    ohai "OpenDerisk installed successfully!"
+    ohai "Next steps:"
+    puts "  1. Configure API keys in: #{etc}/openderisk/derisk-proxy-aliyun.toml"
+    puts "  2. Run: openderisk --help"
+    puts "  3. Start server: openderisk-server"
+    puts ""
+    puts "Documentation: https://github.com/derisk-ai/OpenDerisk"
+  end
+
+  def caveats
+    <<~EOS
+      OpenDerisk Configuration:
+      ========================
+      
+      1. Copy the example config and edit your API keys:
+         cp #{opt_libexec}/configs/derisk-proxy-aliyun.toml ~/.config/openderisk/config.toml
+      
+      2. Edit the config file and add your API keys:
+         nano ~/.config/openderisk/config.toml
+      
+      3. Start the server:
+         openderisk-server
+      
+      4. Or use the CLI:
+         openderisk
+      
+      Requirements:
+      - Python >= 3.10 (installed via Homebrew)
+      - API key for your LLM provider (DeepSeek, OpenAI, etc.)
+    EOS
+  end
+
+  test do
+    system "#{bin}/openderisk", "--version"
+    system "#{bin}/openderisk-server", "--help"
+  end
+end

--- a/homebrew/openderisk.rb
+++ b/homebrew/openderisk.rb
@@ -27,14 +27,14 @@ class Openderisk < Formula
       #!/bin/bash
       export PATH="#{bin}:${PATH}"
       cd "#{libexec}" || exit 1
-      exec uv run python -m derisk "$@"
+      exec uv run derisk "$@"
     EOS
 
     (bin/"openderisk-server").write <<~EOS
       #!/bin/bash
       export PATH="#{bin}:${PATH}"
       cd "#{libexec}" || exit 1
-      exec uv run python -m derisk.serve "$@"
+      exec uv run derisk start webserver "$@"
     EOS
 
     chmod 0755, bin/"openderisk"


### PR DESCRIPTION
## Description
Add Homebrew formula for easy macOS installation.

## Features
- Add openderisk.rb formula for Homebrew
- Auto-install uv and Python dependencies
- Create openderisk and openderisk-server binaries
- Add GitHub Actions workflow for automated formula updates
- Include comprehensive README for tap usage

## Usage
```bash
brew tap derisk-ai/openderisk
brew install openderisk
```

## Files Added
- homebrew/openderisk.rb
- homebrew/README.md
- .github/workflows/homebrew.yml