### PR TITLE
fix: resolve 'No module named derisk.__main__' error from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -161,7 +161,7 @@ create_wrappers() {
 # OpenDerisk Launcher
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.openderisk}"
 cd "$INSTALL_DIR" || exit 1
-exec uv run python -m derisk "$@"
+exec uv run derisk "$@"
 EOF
     
     chmod +x "$BIN_DIR/openderisk"
@@ -172,7 +172,7 @@ EOF
 # OpenDerisk Server Launcher
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.openderisk}"
 cd "$INSTALL_DIR" || exit 1
-exec uv run python -m derisk.serve "$@"
+exec uv run derisk start webserver "$@"
 EOF
     
     chmod +x "$BIN_DIR/openderisk-server"

--- a/packages/derisk-core/src/derisk/__main__.py
+++ b/packages/derisk-core/src/derisk/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running derisk as a module: python -m derisk"""
+
+from derisk.cli.cli_scripts import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Fix `openderisk` and `openderisk-server` commands failing after `install.sh` installation
- Add missing `__main__.py` for `python -m derisk` support
- Update wrapper scripts to use proper entry points

Closes #109

## Root Cause

The wrapper scripts in `install.sh` used `python -m derisk` and `python -m derisk.serve`, but:

1. `derisk` package had no `__main__.py`, causing `No module named derisk.__main__`
2. `derisk.serve` is not a real sub-package (only a lazy-load reference in `__init__.py`), so `python -m derisk.serve` could never work

## Changes

### 1. New file: `packages/derisk-core/src/derisk/__main__.py`

Enables `python -m derisk` by delegating to `derisk.cli.cli_scripts:main` — the same entry point defined in `[project.scripts]`.

### 2. Modified: `install.sh`

Updated wrapper scripts to use `[project.scripts]` console entry points instead of `python -m`:

| Wrapper | Before | After |
|---------|--------|-------|
| `openderisk` | `uv run python -m derisk "$@"` | `uv run derisk "$@"` |
| `openderisk-server` | `uv run python -m derisk.serve "$@"` | `uv run derisk start webserver "$@"` |

## Test Results

All tests passed on macOS (arm64) with Python 3.10+, uv 0.7.x:

| Test | Command | Result |
|------|---------|--------|
| CLI entry point | `uv run derisk --help` | Shows help with all commands |
| Module entry point (was broken) | `uv run python -m derisk --help` | Now works correctly |
| Server startup | `uv run derisk start webserver -c configs/derisk-proxy-aliyun.toml` | Server starts on `0.0.0.0:7777` |
| Health check | `curl http://127.0.0.1:7777/api/health` | `{"status":"ok"}` |
| API docs | `curl http://127.0.0.1:7777/docs` | Swagger UI loads |
| openderisk wrapper | `bash openderisk --help` | Works correctly |
| openderisk-server wrapper | `bash openderisk-server -c <config>` | Server starts and serves |