### PR TITLE
feat: add chat_query API and enhance chat_completions with multiple work modes

### DIFF
--- a/packages/derisk-app/src/derisk_app/openapi/api_v1/api_v1.py
+++ b/packages/derisk-app/src/derisk_app/openapi/api_v1/api_v1.py
@@ -176,8 +176,8 @@ def get_executor() -> Executor:
 
 @router.post("/v1/resource/params/list", response_model=Result[List[dict]])
 async def resource_params_list(
-        resource_type: str,
-        user_token: UserRequest = Depends(get_user_from_headers),
+    resource_type: str,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     if resource_type == "database":
         result = get_db_list()
@@ -189,17 +189,18 @@ async def resource_params_list(
         return Result.succ()
     return Result.succ(result)
 
+
 @router.post("/v1/resource/file/upload")
 async def file_upload(
-        chat_mode: str,
-        conv_uid: str,
-        temperature: Optional[float] = None,
-        max_new_tokens: Optional[int] = None,
-        sys_code: Optional[str] = None,
-        model_name: Optional[str] = None,
-        doc_files: List[UploadFile] = File(...),
-        user_token: UserRequest = Depends(get_user_from_headers),
-        fs: FileStorageClient = Depends(get_fs),
+    chat_mode: str,
+    conv_uid: str,
+    temperature: Optional[float] = None,
+    max_new_tokens: Optional[int] = None,
+    sys_code: Optional[str] = None,
+    model_name: Optional[str] = None,
+    doc_files: List[UploadFile] = File(...),
+    user_token: UserRequest = Depends(get_user_from_headers),
+    fs: FileStorageClient = Depends(get_fs),
 ):
     logger.info(
         f"file_upload:{conv_uid}, files:{[file.filename for file in doc_files]}"
@@ -243,11 +244,11 @@ async def file_upload(
 
 @router.post("/v1/resource/file/delete")
 async def file_delete(
-        conv_uid: str,
-        file_key: str,
-        user_name: Optional[str] = None,
-        sys_code: Optional[str] = None,
-        user_token: UserRequest = Depends(get_user_from_headers),
+    conv_uid: str,
+    file_key: str,
+    user_name: Optional[str] = None,
+    sys_code: Optional[str] = None,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"file_delete:{conv_uid},{file_key}")
     oss_file_client = FileClient()
@@ -259,11 +260,11 @@ async def file_delete(
 
 @router.post("/v1/resource/file/read")
 async def file_read(
-        conv_uid: str,
-        file_key: str,
-        user_name: Optional[str] = None,
-        sys_code: Optional[str] = None,
-        user_token: UserRequest = Depends(get_user_from_headers),
+    conv_uid: str,
+    file_key: str,
+    user_name: Optional[str] = None,
+    sys_code: Optional[str] = None,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"file_read:{conv_uid},{file_key}")
     file_client = FileClient()
@@ -281,8 +282,8 @@ async def get_hist_messages(conv_uid: str, user_name: str = None):
 
 @router.post("/v1/chat/stop")
 async def chat_stop(
-        conv_session_id: str ,
-        user_token: UserRequest = Depends(get_user_from_headers),
+    conv_session_id: str,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"chat_stop:{conv_session_id}")
     try:
@@ -292,11 +293,46 @@ async def chat_stop(
         return Result.failed(msg=f"停止对话失败！{str(e)}")
 
 
+@router.get("/v1/chat/query")
+async def chat_query(
+    conv_id: str,
+    vis_render: Optional[str] = Query(default=None, description="可视化协议名称"),
+    user_token: UserRequest = Depends(get_user_from_headers),
+):
+    """查询会话状态和最终结论
+
+    Args:
+        conv_id: Agent会话ID (agent_conv_id)
+        vis_render: 可视化协议名称
+    """
+    logger.info(f"chat_query: {conv_id}")
+    try:
+        result = await multi_agents.query_chat(
+            conv_id=conv_id,
+            vis_render=vis_render
+        )
+        if result is None:
+            return Result.failed(code="E0103", msg=f"会话 {conv_id} 不存在")
+
+        vis_final, user_answer, current_vis_render, is_final, state = result
+        return Result.succ({
+            "conv_id": conv_id,
+            "state": state,
+            "is_final": is_final,
+            "vis_final": vis_final,
+            "user_answer": user_answer,
+            "vis_render": current_vis_render,
+        })
+    except Exception as e:
+        logger.exception("查询会话异常!")
+        return Result.failed(code="E0104", msg=f"查询会话失败: {str(e)}")
+
+
 @router.post("/v1/chat/completions")
 async def chat_completions(
-        background_tasks: BackgroundTasks,
-        dialogue: ConversationVo = Body(),
-        user_token: UserRequest = Depends(get_user_from_headers),
+    background_tasks: BackgroundTasks,
+    dialogue: ConversationVo = Body(),
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(
         f"chat_completions:{dialogue.team_mode},{dialogue.select_param},"
@@ -305,7 +341,140 @@ async def chat_completions(
 
     if not dialogue.conv_uid:
         dialogue.conv_uid = uuid.uuid1().hex
-    
+
+    # Adapt OpenAI messages format to user_input
+    if not dialogue.user_input and dialogue.messages:
+        try:
+            # Extract the last user message content
+            last_message = next((msg for msg in reversed(dialogue.messages) if msg.get("role") == "user"), None)
+            if last_message:
+                dialogue.user_input = last_message.get("content", "")
+                logger.info(f"Extracted user_input from messages: {dialogue.user_input}")
+        except Exception as e:
+            logger.warning(f"Failed to extract user_input from messages: {e}")
+
+    dialogue.user_name = user_token.user_id if user_token else dialogue.user_name
+    dialogue.ext_info.update(
+        {
+            "trace_id": first(
+                root_tracer.get_context_trace_id(), default=uuid.uuid4().hex
+            )
+        }
+    )
+    dialogue.ext_info.update({"rpc_id": "0.1"})
+
+    headers = {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "Transfer-Encoding": "chunked",
+    }
+    try:
+        dialogue.ext_info.update({"model_name": dialogue.model_name})
+        dialogue.ext_info.update({"incremental": dialogue.incremental})
+        dialogue.ext_info.update({"temperature": dialogue.temperature})
+        dialogue.ext_info.update({"max_new_tokens": dialogue.max_new_tokens})
+
+        in_message = HumanMessage.parse_chat_completion_message(dialogue.user_input, ignore_unknown_media=True)
+
+        work_mode = dialogue.work_mode or WorkMode.ASYNC
+
+        if work_mode == WorkMode.QUICK:
+            async def chat_wrapper():
+                async for chunk, agent_conv_id in multi_agents.quick_app_chat(
+                    conv_session_id=dialogue.conv_uid,
+                    user_query=in_message,
+                    chat_in_params=dialogue.chat_in_params,
+                    app_code=dialogue.app_code,
+                    user_code=dialogue.user_name,
+                    sys_code=dialogue.sys_code,
+                    **dialogue.ext_info,
+                ):
+                    yield chunk
+
+            return StreamingResponse(
+                chat_wrapper(),
+                headers=headers,
+                media_type="text/event-stream",
+            )
+        elif work_mode == WorkMode.BACKGROUND:
+            async def chat_wrapper():
+                async for chunk, agent_conv_id in multi_agents.app_chat_v2(
+                    conv_uid=dialogue.conv_uid,
+                    background_tasks=background_tasks,
+                    gpts_name=dialogue.app_code,
+                    specify_config_code=dialogue.app_config_code,
+                    user_query=in_message,
+                    user_code=dialogue.user_name,
+                    sys_code=dialogue.sys_code,
+                    chat_in_params=dialogue.chat_in_params,
+                    **dialogue.ext_info,
+                ):
+                    yield chunk
+
+            return StreamingResponse(
+                chat_wrapper(),
+                headers=headers,
+                media_type="text/event-stream",
+            )
+        elif work_mode == WorkMode.ASYNC:
+            result = await multi_agents.app_chat_v3(
+                conv_uid=dialogue.conv_uid,
+                background_tasks=background_tasks,
+                gpts_name=dialogue.app_code,
+                specify_config_code=dialogue.app_config_code,
+                user_query=in_message,
+                user_code=dialogue.user_name,
+                sys_code=dialogue.sys_code,
+                chat_in_params=dialogue.chat_in_params,
+                **dialogue.ext_info,
+            )
+            # result 是 (None, agent_conv_id) 元组，提取会话ID
+            agent_conv_id = result[1] if result else None
+            return Result.succ(data={"conv_id": agent_conv_id})
+        else:
+            async def chat_wrapper():
+                async for chunk, agent_conv_id in multi_agents.app_chat(
+                    conv_uid=dialogue.conv_uid,
+                    gpts_name=dialogue.app_code,
+                    specify_config_code=dialogue.app_config_code,
+                    user_query=in_message,
+                    user_code=dialogue.user_name,
+                    sys_code=dialogue.sys_code,
+                    chat_in_params=dialogue.chat_in_params,
+                    **dialogue.ext_info,
+                ):
+                    yield chunk
+
+            return StreamingResponse(
+                chat_wrapper(),
+                headers=headers,
+                media_type="text/event-stream",
+            )
+
+    except Exception as e:
+        logger.exception(f"Chat Exception!{dialogue}", e)
+
+        async def error_text(err_msg):
+            yield f"data:{err_msg}\n\n"
+
+        return StreamingResponse(
+            error_text(str(e)),
+            headers=headers,
+            media_type="text/plain",
+        )
+    finally:
+        # write to recent usage app.
+        if dialogue.user_name is not None and dialogue.app_code is not None:
+            user_recent_app_dao.upsert(
+                user_code=dialogue.user_name,
+                sys_code=dialogue.sys_code,
+                app_code=dialogue.app_code,
+            )
+
+    if not dialogue.conv_uid:
+        dialogue.conv_uid = uuid.uuid1().hex
+
     # Adapt OpenAI messages format to user_input
     if not dialogue.user_input and dialogue.messages:
         try:
@@ -466,7 +635,7 @@ async def chat_completions(
     try:
         if dialogue.team_mode == TeamMode.NATIVE_APP.value:
             with root_tracer.start_span(
-                    "get_chat_instance", span_type=SpanType.CHAT, metadata=dialogue.dict()
+                "get_chat_instance", span_type=SpanType.CHAT, metadata=dialogue.dict()
             ):
                 in_message = HumanMessage.parse_chat_completion_message(dialogue.user_input, ignore_unknown_media=True)
 
@@ -482,6 +651,7 @@ async def chat_completions(
                         **dialogue.ext_info,
                     ):
                         yield chunk
+
                 return StreamingResponse(
                     chat_wrapper(),
                     headers=headers,
@@ -495,6 +665,7 @@ async def chat_completions(
             dialogue.ext_info.update({"max_new_tokens": dialogue.max_new_tokens})
 
             in_message = HumanMessage.parse_chat_completion_message(dialogue.user_input, ignore_unknown_media=True)
+
             async def chat_wrapper():
                 async for chunk, agent_conv_id in multi_agents.app_chat(
                     conv_uid=dialogue.conv_uid,
@@ -508,6 +679,7 @@ async def chat_completions(
                     **dialogue.ext_info,
                 ):
                     yield chunk
+
             return StreamingResponse(
                 chat_wrapper(),
                 headers=headers,
@@ -538,9 +710,9 @@ async def chat_completions(
 
 @router.post("/v1/chat/topic/terminate")
 async def terminate_topic(
-        conv_id: str,
-        round_index: int,
-        user_token: UserRequest = Depends(get_user_from_headers),
+    conv_id: str,
+    round_index: int,
+    user_token: UserRequest = Depends(get_user_from_headers),
 ):
     logger.info(f"terminate_topic:{conv_id},{round_index}")
     try:
@@ -629,12 +801,12 @@ async def no_stream_generator(chat):
 
 
 async def stream_generator(
-        chat,
-        incremental: bool,
-        model_name: str,
-        text_output: bool = True,
-        openai_format: bool = False,
-        conv_uid: str = None,
+    chat,
+    incremental: bool,
+    model_name: str,
+    text_output: bool = True,
+    openai_format: bool = False,
+    conv_uid: str = None,
 ):
     """Generate streaming responses
 
@@ -659,7 +831,7 @@ async def stream_generator(
         if incremental and not openai_format:
             raise ValueError("Incremental response must be openai-compatible format.")
         async for chunk in chat.stream_call(
-                text_output=text_output, incremental=incremental
+            text_output=text_output, incremental=incremental
         ):
             if not chunk:
                 await asyncio.sleep(0.02)


### PR DESCRIPTION
## Summary
- Add new `/v1/chat/query` endpoint to query conversation state and final results
- Enhance `/v1/chat/completions` to support multiple work modes: QUICK, BACKGROUND, ASYNC
- Adapt OpenAI messages format to extract user_input automatically
- Fix code formatting and indentation across multiple API endpoints

## Changes
1. **New API**: `GET /v1/chat/query` - Query conversation status and final conclusion by `conv_id`
2. **Enhanced `chat_completions`**: Support different `work_mode` values:
   - `QUICK`: Quick app chat with streaming response
   - `BACKGROUND`: Background chat with streaming response
   - `ASYNC`: Async chat returning `conv_id` for later querying
3. **OpenAI compatibility**: Auto-extract `user_input` from OpenAI messages format
4. **Code style**: Consistent indentation across endpoint definitions