### PR TITLE
Refactor skill directory discovery with recursive search and deduplication

### DIFF
--- a/packages/derisk-serve/src/derisk_serve/skill/service/service.py
+++ b/packages/derisk-serve/src/derisk_serve/skill/service/service.py
@@ -348,7 +348,7 @@ class Service(BaseService[SkillEntity, SkillRequest, SkillResponse]):
         Returns:
             List[str]: List of skill directory paths containing SKILL.md
         """
-        skill_dirs = []
+        skill_dirs = set()
 
         # Common skill directory patterns
         patterns = [
@@ -363,13 +363,14 @@ class Service(BaseService[SkillEntity, SkillRequest, SkillResponse]):
             if not os.path.isdir(search_path):
                 continue
 
-            for entry in os.scandir(search_path):
-                if entry.is_dir():
-                    skill_md_path = os.path.join(entry.path, "SKILL.md")
-                    if os.path.exists(skill_md_path):
-                        skill_dirs.append(entry.path)
+            # Recursively search for SKILL.md in all subdirectories
+            for root, dirs, files in os.walk(search_path):
+                if "SKILL.md" in files:
+                    skill_dirs.add(root)
+                    # Don't go deeper into subdirectories of a skill directory
+                    dirs[:] = []
 
-        return skill_dirs
+        return list(skill_dirs)
 
     def _parse_skill_md(self, file_path: str) -> Optional[Dict[str, str]]:
         """Parse SKILL.md file to extract metadata.


### PR DESCRIPTION
## Summary
This PR refactors the skill directory discovery logic in `_find_skill_directories()` method to improve robustness and prevent duplicate entries.

## Changes Made
- **Use `set()` instead of `list()`** for `skill_dirs` to automatically deduplicate directory paths
- **Implement recursive search** using `os.walk()` instead of shallow `os.scandir()` to discover skills at any directory depth
- **Prevent redundant traversal** by clearing `dirs[:]` once a skill directory is found (SKILL.md detected)

## Benefits
1. **Deduplication**: Eliminates duplicate skill directories that could occur when multiple patterns match the same directory
2. **Depth flexibility**: Skills can now be organized in nested subdirectories (e.g., `skills/category/my-skill/`)
3. **Performance**: Stops traversing deeper into already-identified skill directories

## Testing
- Verified with nested skill directory structures
- Confirmed no duplicate entries when multiple patterns match
- Validated that skills at various depths are correctly discovered