### PR TITLE
feat: Agent 用户身份识别 + RBAC 登录修复 + 模型配置同步

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,4 @@ configs/local
 /pilot/dataset/
 /openspec/
 /configs/derisk-local.toml
+/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ configs/local
 /pilot/datasets/
 /.claude/
 /pilot/dataset/
+/openspec/
+/configs/derisk-local.toml

--- a/assets/schema/derisk.sql
+++ b/assets/schema/derisk.sql
@@ -9,7 +9,7 @@ use derisk;
 -- MySQL DDL Script for Derisk
 -- Version: 0.3.0
 -- Generated from SQLAlchemy ORM Models
--- Generated: 2026-03-30 22:06:22
+-- Generated: 2026-04-25 20:46:07
 -- ============================================================
 
 SET NAMES utf8mb4;

--- a/configs/derisk-ob.toml
+++ b/configs/derisk-ob.toml
@@ -32,15 +32,35 @@ api_base = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 api_key = "${DASHSCOPE_API_KEY:-sk-...}"
 
 [[agent.llm.provider.model]]
-name = "deepseek-r1"
-temperature = 0.7
-max_new_tokens = 4096
-[[agent.llm.provider.model]]
 name = "deepseek-v3"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
-name = "Kimi-k2"
+name = "deepseek-v3.1"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "deepseek-r1"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "kimi-k2.5"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "kimi-k2.6"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "qwen3.5-plus"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "qwen3.5-flash"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "qwen3-max"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
@@ -51,7 +71,16 @@ max_new_tokens = 4096
 name = "qwen-vl-max"
 temperature = 0.7
 max_new_tokens = 4096
-
+is_multimodal = true
+[[agent.llm.provider.model]]
+name = "qwen3-vl-plus"
+temperature = 0.7
+max_new_tokens = 4096
+is_multimodal = true
+[[agent.llm.provider.model]]
+name = "qwq-plus"
+temperature = 0.7
+max_new_tokens = 4096
 [[agent.llm.provider.model]]
 name = "glm-5"
 temperature = 0.7

--- a/configs/derisk-proxy-aliyun.toml
+++ b/configs/derisk-proxy-aliyun.toml
@@ -32,15 +32,35 @@ api_base = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 api_key = "${DASHSCOPE_API_KEY_2:-sk-...}"
 
 [[agent.llm.provider.model]]
-name = "deepseek-r1"
-temperature = 0.7
-max_new_tokens = 4096
-[[agent.llm.provider.model]]
 name = "deepseek-v3"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
-name = "Kimi-k2"
+name = "deepseek-v3.1"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "deepseek-r1"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "kimi-k2.5"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "kimi-k2.6"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "qwen3.5-plus"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "qwen3.5-flash"
+temperature = 0.7
+max_new_tokens = 4096
+[[agent.llm.provider.model]]
+name = "qwen3-max"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
@@ -51,13 +71,20 @@ max_new_tokens = 4096
 name = "qwen-vl-max"
 temperature = 0.7
 max_new_tokens = 4096
-is_multimodal = true  # 多模态模型，支持图片输入
-
+is_multimodal = true
+[[agent.llm.provider.model]]
+name = "qwen3-vl-plus"
+temperature = 0.7
+max_new_tokens = 4096
+is_multimodal = true
+[[agent.llm.provider.model]]
+name = "qwq-plus"
+temperature = 0.7
+max_new_tokens = 4096
 [[agent.llm.provider.model]]
 name = "glm-5"
 temperature = 0.7
 max_new_tokens = 4096
-is_multimodal = true  # 多模态模型，支持图片输入
 
 [[serves]]
 type = "file"

--- a/configs/derisk-proxy-openai.toml
+++ b/configs/derisk-proxy-openai.toml
@@ -40,24 +40,21 @@ name = "deepseek-v3"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
-name = "Kimi-k2"
+name = "gpt-4o"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
-name = "qwen-plus"
+name = "gpt-4o-mini"
 temperature = 0.7
 max_new_tokens = 4096
 [[agent.llm.provider.model]]
-name = "qwen-vl-max"
+name = "o1"
 temperature = 0.7
 max_new_tokens = 4096
-is_multimodal = true  # 多模态模型，支持图片输入
-
 [[agent.llm.provider.model]]
-name = "glm-5"
+name = "o3-mini"
 temperature = 0.7
 max_new_tokens = 4096
-is_multimodal = true  # 多模态模型，支持图片输入
 
 [[serves]]
 type = "file"

--- a/packages/derisk-app/pyproject.toml
+++ b/packages/derisk-app/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "aiofiles",
     "pyparsing",
     "aiosqlite",
+    "bcrypt",
 ]
 
 [project.urls]

--- a/packages/derisk-app/src/derisk_app/app.py
+++ b/packages/derisk-app/src/derisk_app/app.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -264,12 +264,38 @@ def _sync_oauth2_config_from_db():
         logger.warning(f"Failed to sync OAuth2 from database: {e}")
 
 
+def _convert_toml_agent_llm_to_json_format(toml_agent_llm: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert TOML agent.llm format to JSON agent_llm format.
+
+    TOML format (agent.llm):
+        { "temperature": 0.5, "provider": [{ "provider": "openai", "api_base": "...", "model": [...] }] }
+
+    JSON format (agent_llm):
+        { "temperature": 0.5, "providers": [{ "provider": "openai", "api_base": "...", "models": [...] }] }
+    """
+    result = dict(toml_agent_llm)
+    providers = result.pop("provider", [])
+    json_providers = []
+    for p in providers:
+        if not isinstance(p, dict):
+            continue
+        converted = dict(p)
+        if "model" in converted:
+            converted["models"] = converted.pop("model")
+        json_providers.append(converted)
+    result["providers"] = json_providers
+    return result
+
+
 def _sync_app_config_to_system_app():
     """Sync JSON config (agent_llm, default_model, etc.) to system_app.config on startup.
 
     This ensures that after restart, the LLM configuration saved in derisk.json
     is properly loaded into system_app.config and ModelConfigCache, making models
     available immediately without needing manual refresh.
+
+    When derisk.json has no providers configured but TOML does, the TOML providers
+    are synced back into derisk.json (one-time bootstrap from TOML to JSON config).
     """
     try:
         from derisk_core.config import ConfigManager
@@ -295,6 +321,83 @@ def _sync_app_config_to_system_app():
         from derisk_app.openapi.api_v1.config_api import (
             _convert_agent_llm_to_system_format,
         )
+
+        # Check if JSON config has providers; if empty, try to seed from TOML
+        json_providers = (
+            agent_llm_conf.providers if hasattr(agent_llm_conf, "providers") else []
+        )
+        if not json_providers:
+            # JSON has no providers — check if TOML already loaded providers into system_app.config
+            toml_agent = system_app.config.get("agent", None)
+            toml_llm = toml_agent.get("llm", {}) if isinstance(toml_agent, dict) else None
+
+            if toml_llm and toml_llm.get("provider"):
+                # Bootstrap: sync TOML providers into derisk.json
+                json_llm_dict = _convert_toml_agent_llm_to_json_format(toml_llm)
+                logger.info(
+                    f"Bootstrapping {len(json_llm_dict.get('providers', []))} providers "
+                    f"from TOML config into derisk.json"
+                )
+                try:
+                    from derisk_core.config.schema import AgentLLMConfig, LLMProviderConfig, LLMProviderModelConfig
+
+                    new_providers = []
+                    for p_dict in json_llm_dict.get("providers", []):
+                        models = [
+                            LLMProviderModelConfig(
+                                name=m.get("name", ""),
+                                temperature=m.get("temperature", 0.7),
+                                max_new_tokens=m.get("max_new_tokens", 4096),
+                                is_multimodal=m.get("is_multimodal", False),
+                            )
+                            for m in p_dict.get("models", [])
+                            if isinstance(m, dict) and m.get("name")
+                        ]
+                        if models:
+                            new_providers.append(
+                                LLMProviderConfig(
+                                    provider=p_dict.get("provider", "openai"),
+                                    api_base=p_dict.get("api_base", ""),
+                                    api_key_ref=p_dict.get("api_key_ref", ""),
+                                    models=models,
+                                )
+                            )
+
+                    if new_providers:
+                        cfg.agent_llm = AgentLLMConfig(
+                            temperature=json_llm_dict.get("temperature", 0.5),
+                            providers=new_providers,
+                        )
+                        # Persist to derisk.json
+                        ConfigManager.save()
+                        logger.info("TOML providers saved to derisk.json")
+
+                        # Also store api_key from TOML into secrets if present
+                        for p_dict in json_llm_dict.get("providers", []):
+                            api_key = p_dict.get("api_key", "")
+                            if api_key:
+                                provider_name = p_dict.get("provider", "openai")
+                                try:
+                                    from derisk_core.config.encryption import save_secrets, load_secrets
+
+                                    secrets = load_secrets() or {}
+                                    secret_key = f"{provider_name}_api_key"
+                                    secrets[secret_key] = api_key
+                                    save_secrets(secrets)
+
+                                    # Update provider to use api_key_ref instead
+                                    for p in cfg.agent_llm.providers:
+                                        if p.provider == provider_name:
+                                            p.api_key_ref = f"${{secrets.{secret_key}}}"
+                                    ConfigManager.save()
+                                    logger.info(f"API key for {provider_name} saved to secrets")
+                                except Exception as e:
+                                    logger.warning(f"Failed to save API key to secrets: {e}")
+                except Exception as e:
+                    logger.warning(f"Failed to bootstrap TOML providers into derisk.json: {e}")
+
+                # Refresh agent_llm_conf after bootstrap
+                agent_llm_conf = cfg.agent_llm
 
         agent_llm_dict = _convert_agent_llm_to_system_format(agent_llm_conf)
 

--- a/packages/derisk-app/src/derisk_app/app.py
+++ b/packages/derisk-app/src/derisk_app/app.py
@@ -287,15 +287,100 @@ def _convert_toml_agent_llm_to_json_format(toml_agent_llm: Dict[str, Any]) -> Di
     return result
 
 
+def _bootstrap_toml_providers_to_json(
+    toml_llm: Dict[str, Any], cfg: Any
+) -> bool:
+    """Sync TOML providers into derisk.json config.
+
+    TOML is the source of truth for model configuration. When TOML defines
+    providers, they are always synced into derisk.json so the Web UI and
+    ModelConfigCache see the latest models.
+
+    Returns True if providers were updated, False otherwise.
+    """
+    if not toml_llm or not toml_llm.get("provider"):
+        return False
+
+    from derisk_core.config import ConfigManager
+    from derisk_core.config.schema import (
+        AgentLLMConfig,
+        LLMProviderConfig,
+        LLMProviderModelConfig,
+    )
+
+    json_llm_dict = _convert_toml_agent_llm_to_json_format(toml_llm)
+    toml_providers = json_llm_dict.get("providers", [])
+    if not toml_providers:
+        return False
+
+    new_providers = []
+    for p_dict in toml_providers:
+        models = [
+            LLMProviderModelConfig(
+                name=m.get("name", ""),
+                temperature=m.get("temperature", 0.7),
+                max_new_tokens=m.get("max_new_tokens", 4096),
+                is_multimodal=m.get("is_multimodal", False),
+            )
+            for m in p_dict.get("models", [])
+            if isinstance(m, dict) and m.get("name")
+        ]
+        if models:
+            new_providers.append(
+                LLMProviderConfig(
+                    provider=p_dict.get("provider", "openai"),
+                    api_base=p_dict.get("api_base", ""),
+                    api_key_ref=p_dict.get("api_key_ref", ""),
+                    models=models,
+                )
+            )
+
+    if not new_providers:
+        return False
+
+    # Migrate api_key from TOML into encrypted secrets, set api_key_ref
+    for p_dict in toml_providers:
+        api_key = p_dict.get("api_key", "")
+        if api_key:
+            provider_name = p_dict.get("provider", "openai")
+            try:
+                from derisk_core.config.encryption import save_secrets, load_secrets
+
+                secrets = load_secrets() or {}
+                secret_key = f"{provider_name}_api_key"
+                secrets[secret_key] = api_key
+                save_secrets(secrets)
+
+                for p in new_providers:
+                    if p.provider == provider_name:
+                        p.api_key_ref = f"${{secrets.{secret_key}}}"
+                logger.info(f"API key for {provider_name} saved to secrets")
+            except Exception as e:
+                logger.warning(f"Failed to save API key to secrets: {e}")
+
+    cfg.agent_llm = AgentLLMConfig(
+        temperature=json_llm_dict.get("temperature", 0.5),
+        providers=new_providers,
+    )
+    ConfigManager.save()
+
+    model_names = []
+    for p in new_providers:
+        model_names.extend(m.name for m in p.models)
+    logger.info(
+        f"TOML providers synced to derisk.json: "
+        f"{len(new_providers)} providers, {len(model_names)} models: {model_names}"
+    )
+    return True
+
+
 def _sync_app_config_to_system_app():
-    """Sync JSON config (agent_llm, default_model, etc.) to system_app.config on startup.
+    """Sync LLM config to system_app.config on startup.
 
-    This ensures that after restart, the LLM configuration saved in derisk.json
-    is properly loaded into system_app.config and ModelConfigCache, making models
-    available immediately without needing manual refresh.
-
-    When derisk.json has no providers configured but TOML does, the TOML providers
-    are synced back into derisk.json (one-time bootstrap from TOML to JSON config).
+    Priority: TOML config > JSON config. If TOML defines providers, they always
+    override the JSON (derisk.json) providers. This ensures edits to TOML files
+    take effect on next restart, while the Web UI can still hot-reload within a
+    session (Web UI writes to derisk.json, which takes effect until next restart).
     """
     try:
         from derisk_core.config import ConfigManager
@@ -322,86 +407,24 @@ def _sync_app_config_to_system_app():
             _convert_agent_llm_to_system_format,
         )
 
-        # Check if JSON config has providers; if empty, try to seed from TOML
-        json_providers = (
-            agent_llm_conf.providers if hasattr(agent_llm_conf, "providers") else []
-        )
-        if not json_providers:
-            # JSON has no providers — check if TOML already loaded providers into system_app.config
-            toml_agent = system_app.config.get("agent", None)
-            toml_llm = toml_agent.get("llm", {}) if isinstance(toml_agent, dict) else None
-
-            if toml_llm and toml_llm.get("provider"):
-                # Bootstrap: sync TOML providers into derisk.json
-                json_llm_dict = _convert_toml_agent_llm_to_json_format(toml_llm)
-                logger.info(
-                    f"Bootstrapping {len(json_llm_dict.get('providers', []))} providers "
-                    f"from TOML config into derisk.json"
-                )
-                try:
-                    from derisk_core.config.schema import AgentLLMConfig, LLMProviderConfig, LLMProviderModelConfig
-
-                    new_providers = []
-                    for p_dict in json_llm_dict.get("providers", []):
-                        models = [
-                            LLMProviderModelConfig(
-                                name=m.get("name", ""),
-                                temperature=m.get("temperature", 0.7),
-                                max_new_tokens=m.get("max_new_tokens", 4096),
-                                is_multimodal=m.get("is_multimodal", False),
-                            )
-                            for m in p_dict.get("models", [])
-                            if isinstance(m, dict) and m.get("name")
-                        ]
-                        if models:
-                            new_providers.append(
-                                LLMProviderConfig(
-                                    provider=p_dict.get("provider", "openai"),
-                                    api_base=p_dict.get("api_base", ""),
-                                    api_key_ref=p_dict.get("api_key_ref", ""),
-                                    models=models,
-                                )
-                            )
-
-                    if new_providers:
-                        cfg.agent_llm = AgentLLMConfig(
-                            temperature=json_llm_dict.get("temperature", 0.5),
-                            providers=new_providers,
-                        )
-                        # Persist to derisk.json
-                        ConfigManager.save()
-                        logger.info("TOML providers saved to derisk.json")
-
-                        # Also store api_key from TOML into secrets if present
-                        for p_dict in json_llm_dict.get("providers", []):
-                            api_key = p_dict.get("api_key", "")
-                            if api_key:
-                                provider_name = p_dict.get("provider", "openai")
-                                try:
-                                    from derisk_core.config.encryption import save_secrets, load_secrets
-
-                                    secrets = load_secrets() or {}
-                                    secret_key = f"{provider_name}_api_key"
-                                    secrets[secret_key] = api_key
-                                    save_secrets(secrets)
-
-                                    # Update provider to use api_key_ref instead
-                                    for p in cfg.agent_llm.providers:
-                                        if p.provider == provider_name:
-                                            p.api_key_ref = f"${{secrets.{secret_key}}}"
-                                    ConfigManager.save()
-                                    logger.info(f"API key for {provider_name} saved to secrets")
-                                except Exception as e:
-                                    logger.warning(f"Failed to save API key to secrets: {e}")
-                except Exception as e:
-                    logger.warning(f"Failed to bootstrap TOML providers into derisk.json: {e}")
-
-                # Refresh agent_llm_conf after bootstrap
-                agent_llm_conf = cfg.agent_llm
+        # TOML config is the source of truth — always sync to derisk.json
+        toml_agent = system_app.config.get("agent", None)
+        toml_llm = toml_agent.get("llm", {}) if isinstance(toml_agent, dict) else None
+        if toml_llm and toml_llm.get("provider"):
+            _bootstrap_toml_providers_to_json(toml_llm, cfg)
+            # Refresh after sync
+            agent_llm_conf = cfg.agent_llm
 
         agent_llm_dict = _convert_agent_llm_to_system_format(agent_llm_conf)
 
         system_app.config.set("agent.llm", agent_llm_dict)
+
+        # Also update app_config so model list endpoints see the latest providers.
+        # The endpoints check app_config.agent_llm first (PRIORITY 1), so it must
+        # be kept in sync; otherwise stale data blocks the fallback paths.
+        app_config = system_app.config.configs.get("app_config")
+        if app_config and hasattr(app_config, "agent_llm"):
+            app_config.agent_llm = agent_llm_conf
 
         model_configs = parse_provider_configs(agent_llm_dict)
         if model_configs:

--- a/packages/derisk-app/src/derisk_app/app.py
+++ b/packages/derisk-app/src/derisk_app/app.py
@@ -252,6 +252,7 @@ def _sync_oauth2_config_from_db():
                 enabled=db_oauth2.get("enabled", False),
                 providers=db_oauth2.get("providers", []),
                 admin_users=db_oauth2.get("admin_users", []),
+                default_role=db_oauth2.get("default_role", "viewer"),
             )
             cfg.oauth2 = oauth2_config
             logger.info(

--- a/packages/derisk-app/src/derisk_app/auth/user_service.py
+++ b/packages/derisk-app/src/derisk_app/auth/user_service.py
@@ -11,6 +11,46 @@ from derisk.storage.metadata import BaseDao, Model
 logger = logging.getLogger(__name__)
 
 
+def _ensure_user_has_role(user_id: int, rbac_default_role: str = "viewer") -> None:
+    """Ensure a user has at least one RBAC role assigned.
+
+    If the user already has roles, this is a no-op.
+    If not, the configured default role (or 'viewer' as fallback) is assigned.
+    """
+    try:
+        from derisk_app.feature_plugins.permissions.dao import PermissionDao
+
+        dao = PermissionDao()
+        existing_roles = dao.get_user_roles(user_id)
+        if existing_roles:
+            return
+
+        # No roles assigned — assign the default role
+        default_role = dao.get_role_by_name(rbac_default_role)
+        if default_role:
+            dao.assign_role_to_user(user_id, default_role["id"])
+            logger.info(
+                f"Auto-assigned '{rbac_default_role}' role to user {user_id} (missing RBAC role)"
+            )
+        else:
+            viewer_role = dao.get_role_by_name("viewer")
+            if viewer_role:
+                dao.assign_role_to_user(user_id, viewer_role["id"])
+                logger.warning(
+                    f"Configured default role '{rbac_default_role}' not found, "
+                    f"fallback to 'viewer' for user {user_id}"
+                )
+            else:
+                logger.error(
+                    f"Neither '{rbac_default_role}' nor 'viewer' role found in RBAC — "
+                    f"user {user_id} has no permissions"
+                )
+    except ImportError:
+        logger.debug("Permissions plugin not available, skipping RBAC role assignment")
+    except Exception as e:
+        logger.error(f"Failed to auto-assign default RBAC role to user {user_id}: {e}")
+
+
 class UserEntity(Model):
     """User entity matching the user table schema."""
 
@@ -22,6 +62,7 @@ class UserEntity(Model):
     oauth_id = Column(String(255), nullable=True, comment="OAuth provider user ID")
     email = Column(String(255), nullable=True, comment="User email")
     avatar = Column(String(512), nullable=True, comment="Avatar URL")
+    password_hash = Column(String(255), nullable=True, comment="Bcrypt password hash for local login")
     role = Column(
         String(20), nullable=True, default="normal", comment="User role: normal/admin"
     )
@@ -124,7 +165,12 @@ class UserDao(BaseDao):
                 merged = session.merge(user)
                 session.commit()
                 session.refresh(merged)
-                return _entity_to_dict(merged)
+                user_dict = _entity_to_dict(merged)
+
+                # Ensure existing user has an RBAC role assigned
+                _ensure_user_has_role(user.id, rbac_default_role)
+
+                return user_dict
             else:
                 user = UserEntity(
                     name=name,
@@ -141,27 +187,7 @@ class UserDao(BaseDao):
                 session.refresh(user)
 
                 # 自动为新用户分配配置的默认角色
-                try:
-                    from derisk_app.feature_plugins.permissions.dao import PermissionDao
-
-                    dao = PermissionDao()
-                    default_role = dao.get_role_by_name(rbac_default_role)
-                    if default_role:
-                        dao.assign_role_to_user(user.id, default_role["id"])
-                        logger.info(
-                            f"Auto-assigned {rbac_default_role} role to new OAuth2 user: {user.id} ({user.name})"
-                        )
-                    else:
-                        # Fallback to viewer if configured role doesn't exist
-                        viewer_role = dao.get_role_by_name("viewer")
-                        if viewer_role:
-                            dao.assign_role_to_user(user.id, viewer_role["id"])
-                            logger.warning(
-                                f"Configured default role '{rbac_default_role}' not found, "
-                                f"fallback to viewer for new OAuth2 user: {user.id} ({user.name})"
-                            )
-                except Exception as e:
-                    logger.warning(f"Failed to auto-assign default role: {e}")
+                _ensure_user_has_role(user.id, rbac_default_role)
 
                 return _entity_to_dict(user)
 
@@ -195,7 +221,10 @@ class UserDao(BaseDao):
         role: Optional[str] = None,
         is_active: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Update user role or is_active status."""
+        """Update user role or is_active status.
+
+        When role is set to "admin", the RBAC admin role is also assigned.
+        """
         with self.session() as session:
             user = session.query(UserEntity).filter(UserEntity.id == user_id).first()
             if not user:
@@ -206,6 +235,11 @@ class UserDao(BaseDao):
                 user.is_active = is_active
             session.commit()
             session.refresh(user)
+
+            # Sync legacy role to RBAC: setting admin assigns RBAC admin role
+            if role == "admin":
+                _ensure_user_has_role(user_id, "admin")
+
             return _entity_to_dict(user)
 
     def delete_user(self, user_id: int) -> bool:
@@ -225,6 +259,77 @@ class UserDao(BaseDao):
             session.commit()
             logger.info(f"User {user_id} ({user.name}) soft deleted")
             return True
+
+    def verify_local_login(
+        self, username: str, password: str
+    ) -> Optional[Dict[str, Any]]:
+        """Verify username/password for local login.
+
+        Returns user dict on success, None on failure.
+        """
+        import hashlib
+
+        with self.session() as session:
+            user = (
+                session.query(UserEntity)
+                .filter(
+                    UserEntity.oauth_provider == "local",
+                    UserEntity.name == username,
+                    UserEntity.is_active == 1,
+                )
+                .first()
+            )
+            if not user or not user.password_hash:
+                return None
+
+            try:
+                import bcrypt
+
+                if not bcrypt.checkpw(
+                    password.encode("utf-8"), user.password_hash.encode("utf-8")
+                ):
+                    return None
+            except ImportError:
+                # Fallback to SHA256 if bcrypt not available
+                sha = hashlib.sha256(password.encode("utf-8")).hexdigest()
+                if user.password_hash != sha:
+                    return None
+
+            return _entity_to_dict(user)
+
+    def set_password(self, user_id: int, password: str) -> bool:
+        """Set password for a user (bcrypt hash)."""
+        try:
+            import bcrypt
+
+            password_hash = bcrypt.hashpw(
+                password.encode("utf-8"), bcrypt.gensalt()
+            ).decode("utf-8")
+        except ImportError:
+            import hashlib
+
+            password_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+        with self.session() as session:
+            user = session.query(UserEntity).filter(UserEntity.id == user_id).first()
+            if not user:
+                return False
+            user.password_hash = password_hash
+            session.commit()
+            return True
+
+    def has_local_users(self) -> bool:
+        """Check if any local users with passwords exist."""
+        with self.session() as session:
+            return (
+                session.query(UserEntity)
+                .filter(
+                    UserEntity.oauth_provider == "local",
+                    UserEntity.password_hash.isnot(None),
+                )
+                .first()
+                is not None
+            )
 
 
 class UserService:
@@ -298,4 +403,29 @@ class UserService:
             return self._dao.delete_user(user_id)
         except Exception as e:
             logger.exception(f"Failed to delete user {user_id}: {e}")
+            return False
+
+    def verify_local_login(
+        self, username: str, password: str
+    ) -> Optional[Dict[str, Any]]:
+        """Verify username/password for local login."""
+        try:
+            return self._dao.verify_local_login(username, password)
+        except Exception as e:
+            logger.exception(f"Failed to verify local login: {e}")
+            return None
+
+    def set_password(self, user_id: int, password: str) -> bool:
+        """Set password for a user."""
+        try:
+            return self._dao.set_password(user_id, password)
+        except Exception as e:
+            logger.exception(f"Failed to set password for user {user_id}: {e}")
+            return False
+
+    def has_local_users(self) -> bool:
+        """Check if any local users with passwords exist."""
+        try:
+            return self._dao.has_local_users()
+        except Exception:
             return False

--- a/packages/derisk-app/src/derisk_app/base.py
+++ b/packages/derisk-app/src/derisk_app/base.py
@@ -207,16 +207,18 @@ def _migrate_mysql_chat_tables_utf8mb4(db_url: str) -> None:
         logger.error("MySQL utf8mb4 migration for chat tables failed: %s", e)
 
 
-def _add_missing_columns_sqlite(db):
-    """Add missing columns to existing SQLite tables (ALTER TABLE ADD COLUMN).
+def _add_missing_columns(db):
+    """Add missing columns to existing tables (ALTER TABLE ADD COLUMN).
 
     SQLAlchemy's create_all() only creates new tables; it won't add columns to
     existing ones. This function inspects the current schema and adds any column
     that is defined in a mapped model but absent from the actual table.
+    Works for both SQLite and MySQL.
     """
     from sqlalchemy import inspect as sa_inspect, text
 
     engine = db.engine
+    dialect_name = engine.dialect.name
     inspector = sa_inspect(engine)
     existing_tables = inspector.get_table_names()
 
@@ -240,9 +242,13 @@ def _add_missing_columns_sqlite(db):
                 default_clause = ""
                 if col.default is not None and col.default.is_scalar:
                     default_clause = f" DEFAULT '{col.default.arg}'"
+                comment_clause = ""
+                if dialect_name == "mysql" and col.comment:
+                    escaped = col.comment.replace("'", "\\'")
+                    comment_clause = f" COMMENT '{escaped}'"
                 try:
                     stmt = text(
-                        f"ALTER TABLE {table.name} ADD COLUMN {col.name} {col_type} {nullable}{default_clause}"
+                        f"ALTER TABLE {table.name} ADD COLUMN {col.name} {col_type} {nullable}{default_clause}{comment_clause}"
                     )
                     conn.execute(stmt)
                     conn.commit()
@@ -283,23 +289,25 @@ def _migration_db_storage(
                     f"Create all tables stored in this metadata error: {str(e)}"
                 )
 
-            _add_missing_columns_sqlite(db)
+            _add_missing_columns(db)
 
             db.engine.dispose()
 
             _ddl_init_and_upgrade(default_meta_data_path, disable_alembic_upgrade)
         else:
-            warn_msg = """For safety considerations, MySQL Database not support DDL \
-            init and upgrade. "
-                "1.If you are use DERISK firstly, please manually execute the following\
-                 command to initialize, 
-                `mysql -h127.0.0.1 -uroot -p{your_password} \
-                < ./assets/schema/derisk.sql` "
-                "2.If there are any changes to the table columns in the DERISK database,
-                 it is necessary to compare with the DERISK/assets/schema/derisk.sql file
-                 and manually make the columns changes in the MySQL database instance.
-                 """
-            logger.warning(warn_msg)
+            # MySQL: create new tables + auto-add missing columns
+            try:
+                db.create_all()
+            except Exception as e:
+                logger.warning(
+                    f"Create all tables stored in this metadata error: {str(e)}"
+                )
+
+            _add_missing_columns(db)
+
+            db.engine.dispose()
+
+            _ddl_init_and_upgrade(default_meta_data_path, disable_alembic_upgrade)
 
 
 def _initialize_db(

--- a/packages/derisk-app/src/derisk_app/feature_plugins/permissions/api.py
+++ b/packages/derisk-app/src/derisk_app/feature_plugins/permissions/api.py
@@ -61,7 +61,7 @@ class GroupRoleAssignBody(BaseModel):
 # ========== Role Management ==========
 @router.get("/roles")
 async def list_roles(
-    _user: UserRequest = Depends(require_permission("system", "read")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     roles = _dao.list_roles()
     return {"success": True, "data": roles}
@@ -82,7 +82,7 @@ async def create_role(
 @router.get("/roles/{role_id}")
 async def get_role(
     role_id: int,
-    _user: UserRequest = Depends(require_permission("system", "read")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     r = _dao.get_role(role_id)
     if not r:
@@ -124,7 +124,7 @@ async def delete_role(
 @router.get("/roles/{role_id}/permissions")
 async def list_role_permissions(
     role_id: int,
-    _user: UserRequest = Depends(require_permission("system", "admin")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     perms = _dao.list_role_permissions(role_id)
     return {"success": True, "data": perms}
@@ -290,7 +290,7 @@ async def list_users(
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
     keyword: str = Query(""),
-    _user: UserRequest = Depends(require_permission("system", "admin")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """列出所有用户（分页）"""
     from derisk_app.auth.user_service import UserService
@@ -333,7 +333,7 @@ async def list_users(
 @router.get("/users/{user_id}")
 async def get_user_detail(
     user_id: int,
-    _user: UserRequest = Depends(require_permission("system", "admin")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """获取用户详情（含角色信息）"""
     from derisk_app.auth.user_service import UserService
@@ -374,7 +374,7 @@ async def get_user_detail(
 @router.get("/users/{user_id}/effective-permissions")
 async def get_user_effective_permissions(
     user_id: int,
-    _user: UserRequest = Depends(require_permission("system", "admin")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """获取用户的生效权限（含组继承）"""
     from derisk_app.auth.user_service import UserService
@@ -615,7 +615,7 @@ async def list_permission_definitions(
     resource_type: Optional[str] = Query(None),
     action: Optional[str] = Query(None),
     is_active: Optional[bool] = Query(None),
-    _user: UserRequest = Depends(require_permission("system", "read")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """列出权限定义"""
     definitions = _def_svc.list_permission_definitions(
@@ -651,7 +651,7 @@ async def create_permission_definition(
 @router.get("/definitions/{definition_id}")
 async def get_permission_definition(
     definition_id: int,
-    _user: UserRequest = Depends(require_permission("system", "read")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """获取权限定义详情"""
     p = _def_svc.get_permission_definition(definition_id)
@@ -705,7 +705,7 @@ async def delete_permission_definition(
 @router.get("/roles/{role_id}/permission-defs")
 async def get_role_permission_defs(
     role_id: int,
-    _user: UserRequest = Depends(require_permission("system", "read")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """获取角色关联的权限定义"""
     # 验证角色存在

--- a/packages/derisk-app/src/derisk_app/feature_plugins/permissions/seed.py
+++ b/packages/derisk-app/src/derisk_app/feature_plugins/permissions/seed.py
@@ -190,9 +190,11 @@ def ensure_default_roles() -> None:
     # 2. 创建默认 admin 用户并分配角色
     if admin_role_id:
         try:
-            from derisk_app.auth.user_service import UserEntity
+            from derisk_app.auth.user_service import UserEntity, UserDao
             from derisk.storage.metadata.db_manager import db
             from datetime import datetime
+
+            default_password = "admin"
 
             with db.session(commit=True) as s:
                 # 检查是否已存在 admin 用户（通过 oauth_id 或 name）
@@ -212,8 +214,13 @@ def ensure_default_roles() -> None:
                     if not has_admin_role:
                         dao.assign_role_to_user(admin_user_id, admin_role_id)
                         logger.info("Assigned admin role to existing admin user")
+                    # 确保已有 admin 用户有密码
+                    if not existing_admin.password_hash:
+                        user_dao = UserDao()
+                        user_dao.set_password(admin_user_id, default_password)
+                        logger.info("Set default password for existing admin user")
                 else:
-                    # 创建新的 admin 用户
+                    # 创建新的 admin 用户（先不含密码，通过 UserDao.set_password 设置）
                     user = UserEntity(
                         name="admin",
                         fullname="System Administrator",
@@ -230,21 +237,62 @@ def ensure_default_roles() -> None:
                     admin_user_id = user.id
                     s.commit()
 
+                    # 设置密码
+                    user_dao = UserDao()
+                    user_dao.set_password(admin_user_id, default_password)
+
                     # 分配 admin 角色
                     dao.assign_role_to_user(admin_user_id, admin_role_id)
                     logger.info(f"Created default admin user (ID={admin_user_id}) and assigned admin role")
                     logger.info("=" * 60)
                     logger.info("DEFAULT ADMIN USER CREATED:")
                     logger.info("  Username: admin")
-                    logger.info("  OAuth Provider: local (bypass OAuth for local admin)")
+                    logger.info("  Password: admin (please change after first login)")
+                    logger.info("  OAuth Provider: local")
                     logger.info(f"  User ID: {admin_user_id}")
-                    logger.info("  Note: Use OAuth2 login or set X-User-ID: admin header for testing")
                     logger.info("=" * 60)
         except Exception as e:
             logger.warning(f"Failed to create/assign admin user: {e}")
 
-    # 3. 创建默认权限定义
+    # 3. 为存量用户（无 RBAC 角色）补分配默认角色
+    _backfill_default_role_for_existing_users(dao)
+
+    # 4. 创建默认权限定义
     _ensure_default_permission_definitions(dao)
+
+
+def _backfill_default_role_for_existing_users(dao: PermissionDao) -> None:
+    """Assign default 'viewer' role to existing users who have no RBAC roles.
+
+    This handles users created before the RBAC plugin was enabled, or users
+    whose role assignment failed silently during OAuth2 login.
+    """
+    try:
+        from derisk_app.auth.user_service import UserEntity
+        from derisk.storage.metadata.db_manager import db
+
+        viewer_role = dao.get_role_by_name("viewer")
+        if not viewer_role:
+            logger.warning("viewer role not found, skipping existing user backfill")
+            return
+
+        with db.session() as session:
+            all_users = session.query(UserEntity).filter(UserEntity.is_active == 1).all()
+            backfilled = 0
+            for user in all_users:
+                existing_roles = dao.get_user_roles(user.id)
+                if not existing_roles:
+                    dao.assign_role_to_user(user.id, viewer_role["id"])
+                    backfilled += 1
+                    logger.info(
+                        f"Backfilled 'viewer' role for existing user: {user.id} ({user.name})"
+                    )
+            if backfilled > 0:
+                logger.info(f"Backfilled 'viewer' role for {backfilled} existing users")
+    except ImportError:
+        logger.debug("UserEntity not available, skipping existing user backfill")
+    except Exception as e:
+        logger.error(f"Failed to backfill default role for existing users: {e}")
 
 
 def _ensure_default_permission_definitions(dao: PermissionDao) -> None:

--- a/packages/derisk-app/src/derisk_app/openapi/api_v1/api_v1.py
+++ b/packages/derisk-app/src/derisk_app/openapi/api_v1/api_v1.py
@@ -59,7 +59,7 @@ from derisk_serve.agent.team.base import TeamMode
 from derisk_serve.core import blocking_func_to_async
 from derisk_serve.datasource.manages.db_conn_info import DBConfig, DbTypeInfo
 from derisk_serve.flow.service.service import Service as FlowService
-from derisk_serve.utils.auth import UserRequest, get_user_from_headers
+from derisk_serve.utils.auth import UserRequest, get_user_from_headers, build_user_context, _is_permissions_enabled
 
 router = APIRouter()
 CFG = Config()
@@ -430,6 +430,16 @@ async def chat_completions(
             logger.warning(f"Failed to extract user_input from messages: {e}")
 
     dialogue.user_name = user_token.user_id if user_token else dialogue.user_name
+
+    # 注入用户上下文信息（身份、角色、权限），供 Agent 工具查询
+    if user_token:
+        try:
+            dialogue.ext_info["user_context"] = build_user_context(
+                user_token, rbac_enabled=_is_permissions_enabled()
+            )
+        except Exception:
+            logger.warning("Failed to build user context for agent tools", exc_info=True)
+
     dialogue.ext_info.update(
         {
             "trace_id": first(

--- a/packages/derisk-app/src/derisk_app/openapi/api_v1/auth_api.py
+++ b/packages/derisk-app/src/derisk_app/openapi/api_v1/auth_api.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, RedirectResponse
+from pydantic import BaseModel
 
 from derisk_app.auth.oauth import OAuth2Service
 from derisk_app.auth.session import (
@@ -19,6 +20,11 @@ router = APIRouter(prefix="/auth", tags=["Auth"])
 
 oauth_service = OAuth2Service()
 session_manager = SessionManager()
+
+
+class LocalLoginRequest(BaseModel):
+    username: str
+    password: str
 
 
 def _get_config():
@@ -79,25 +85,35 @@ def _resolve_role(user_info: Dict[str, Any]) -> tuple[str, str]:
 @router.get("/oauth/status")
 async def oauth_status():
     """Return whether OAuth2 is enabled and available providers (for frontend)."""
+    from derisk_app.auth.user_service import UserService
+
     oauth_config = _get_oauth_config()
     if not oauth_config:
-        return JSONResponse(
-            content={
-                "enabled": False,
-                "providers": [],
-            }
-        )
-    providers = oauth_config.get("providers", [])
-    # Only include providers with client_id configured
-    available = [
-        {"id": p["id"], "type": p.get("type", "custom")}
-        for p in providers
-        if p.get("client_id")
-    ]
+        oauth_enabled = False
+        providers = []
+    else:
+        providers = oauth_config.get("providers", [])
+        available = [
+            {"id": p["id"], "type": p.get("type", "custom")}
+            for p in providers
+            if p.get("client_id")
+        ]
+        oauth_enabled = True
+        providers = available
+
+    # Check if local login is available
+    local_login_enabled = False
+    try:
+        svc = UserService()
+        local_login_enabled = svc.has_local_users()
+    except Exception:
+        pass
+
     return JSONResponse(
         content={
-            "enabled": True,
-            "providers": available,
+            "enabled": oauth_enabled,
+            "providers": providers,
+            "local_login_enabled": local_login_enabled,
         }
     )
 
@@ -207,6 +223,44 @@ async def oauth_callback(
     redirect_to = f"{base}/auth/callback/#token={token}"
     response = RedirectResponse(url=redirect_to, status_code=302)
     # Also set cookie for same-origin requests
+    response.set_cookie(
+        key="derisk_session",
+        value=token,
+        httponly=True,
+        secure=request.url.scheme == "https",
+        samesite="lax",
+        max_age=7 * 24 * 3600,
+    )
+    return response
+
+
+@router.post("/login")
+async def local_login(body: LocalLoginRequest, request: Request):
+    """Local username/password login for admin and local users."""
+    from derisk_app.auth.user_service import UserService
+
+    svc = UserService()
+    user = svc.verify_local_login(body.username, body.password)
+    if not user:
+        raise HTTPException(status_code=401, detail="用户名或密码错误")
+
+    token = create_session_token(user)
+
+    response = JSONResponse(
+        content={
+            "success": True,
+            "data": {
+                "user": user,
+                "user_channel": "local",
+                "user_no": str(user.get("id", "")),
+                "nick_name": user.get("name", user.get("fullname", "")),
+                "avatar_url": user.get("avatar", ""),
+                "email": user.get("email", ""),
+                "role": user.get("role", "normal"),
+                "token": token,
+            },
+        }
+    )
     response.set_cookie(
         key="derisk_session",
         value=token,

--- a/packages/derisk-app/src/derisk_app/openapi/api_v1/users_api.py
+++ b/packages/derisk-app/src/derisk_app/openapi/api_v1/users_api.py
@@ -35,6 +35,7 @@ async def list_users(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100),
     keyword: str = Query(default=""),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """List users with pagination and optional keyword filter."""
     svc = _get_user_service()
@@ -51,7 +52,10 @@ async def list_users(
 
 
 @router.get("/{user_id}")
-async def get_user(user_id: int):
+async def get_user(
+    user_id: int,
+    _user: UserRequest = Depends(get_user_from_headers),
+):
     """Get user by id."""
     svc = _get_user_service()
     user = svc.get_user(user_id)
@@ -61,7 +65,11 @@ async def get_user(user_id: int):
 
 
 @router.patch("/{user_id}")
-async def update_user(user_id: int, body: UpdateUserRequest):
+async def update_user(
+    user_id: int,
+    body: UpdateUserRequest,
+    _user: UserRequest = Depends(require_admin()),
+):
     """Update user role or is_active status."""
     if body.role is None and body.is_active is None:
         raise HTTPException(status_code=400, detail="Nothing to update")
@@ -125,7 +133,7 @@ async def delete_user(
 @router.get("/{user_id}/permissions")
 async def get_user_permissions(
     user_id: int,
-    _user: UserRequest = Depends(require_permission("system", "admin")),
+    _user: UserRequest = Depends(get_user_from_headers),
 ):
     """Get user's effective permissions including scoped resource permissions.
 

--- a/packages/derisk-core/src/derisk/agent/expand/actions/tool_action.py
+++ b/packages/derisk-core/src/derisk/agent/expand/actions/tool_action.py
@@ -903,16 +903,25 @@ class ToolAction(Action[ToolInput]):
                     if k not in arguments:
                         arguments[k] = v
 
-                # Build context with sandbox_manager for sandbox tools
-                tool_context = None
+                # Build context with user_context and sandbox_manager
+                tool_context = {}
+
+                # Extract user context from agent for user identity tools
+                if agent and hasattr(agent, "agent_context"):
+                    agent_ctx = agent.agent_context
+                    extra = getattr(agent_ctx, "extra", None)
+                    if extra and isinstance(extra, dict) and "user_context" in extra:
+                        tool_context["user_context"] = extra["user_context"]
+
+                # Include sandbox_manager for sandbox tools
                 if (
                     agent
                     and hasattr(agent, "sandbox_manager")
                     and agent.sandbox_manager
                 ):
-                    tool_context = {"sandbox_manager": agent.sandbox_manager}
+                    tool_context["sandbox_manager"] = agent.sandbox_manager
 
-                # Merge system context into arguments before filtering
+                # Merge context into arguments before filtering
                 if tool_context:
                     arguments["context"] = tool_context
 
@@ -928,8 +937,10 @@ class ToolAction(Action[ToolInput]):
                     sig = _inspect.signature(tool_info._func)
                     valid_keys = {p for p in sig.parameters if p not in ("self", "cls")}
 
-                # Save context before filtering (for sandbox tools)
-                # SandboxToolBase tools need context to get sandbox_client
+                # Save context before filtering (for tools that need context)
+                # ToolBase.execute() receives context as a separate parameter,
+                # and async_execute() pops "context" from kwargs before forwarding.
+                # So it's safe to always restore context — it won't pollute tool args.
                 saved_context = arguments.get("context")
 
                 if valid_keys is not None:
@@ -942,28 +953,12 @@ class ToolAction(Action[ToolInput]):
                         )
                     arguments = {k: v for k, v in arguments.items() if k in valid_keys}
 
-                # Restore context for sandbox tools if it was filtered out
-                # Check if tool needs sandbox context by checking _get_sandbox_client method
-                # (inherited from SandboxToolBase) or by checking tool_info._tool_base
-                needs_sandbox_context = False
-                if saved_context:
-                    # Check if this is a UnifiedToolAdapter wrapping a SandboxToolBase
-                    if hasattr(tool_info, "_tool_base"):
-                        tool_base = tool_info._tool_base
-                        if hasattr(tool_base, "_get_sandbox_client"):
-                            needs_sandbox_context = True
-                    # Check if tool_info itself has _get_sandbox_client (direct SandboxToolBase)
-                    elif hasattr(tool_info, "_get_sandbox_client"):
-                        needs_sandbox_context = True
-                    # Check if tool has "context" in its args definition
-                    elif hasattr(tool_info, "args") and "context" in (
-                        tool_info.args or {}
-                    ):
-                        needs_sandbox_context = True
-
-                if needs_sandbox_context and saved_context:
+                # Restore context if it was filtered out
+                # async_execute() pops "context" from kwargs and passes it to
+                # execute() separately, so restoring is safe for all tools.
+                if saved_context and "context" not in arguments:
                     arguments["context"] = saved_context
-                    logger.debug(f"Restored context for sandbox tool: {tool_info.name}")
+                    logger.debug(f"Restored context for tool: {tool_info.name}")
 
                 if tool_info.is_async:
                     raw_content = await tool_info.async_execute(**arguments)

--- a/packages/derisk-core/src/derisk/agent/tools/agent_adapter.py
+++ b/packages/derisk-core/src/derisk/agent/tools/agent_adapter.py
@@ -257,6 +257,11 @@ class AgentToolAdapter:
                 )
                 context.setdefault("user_id", getattr(agent_ctx, "user_id", None))
 
+                # 提取用户上下文信息（身份、角色、权限等）
+                extra = getattr(agent_ctx, "extra", None)
+                if extra and isinstance(extra, dict) and "user_context" in extra:
+                    context.setdefault("user_context", extra["user_context"])
+
             # CoreV2 Agent特有字段
             if hasattr(self._agent, "context"):
                 agent_ctx = self._agent.context

--- a/packages/derisk-core/src/derisk/agent/tools/builtin/__init__.py
+++ b/packages/derisk-core/src/derisk/agent/tools/builtin/__init__.py
@@ -75,3 +75,8 @@ def register_all(registry: "ToolRegistry") -> None:
     from .todo import register_todo_tools
 
     register_todo_tools(registry)
+
+    # 用户身份工具 (get_user_info, get_user_permissions)
+    from .user_identity import register_user_identity_tools
+
+    register_user_identity_tools(registry)

--- a/packages/derisk-core/src/derisk/agent/tools/builtin/user_identity/__init__.py
+++ b/packages/derisk-core/src/derisk/agent/tools/builtin/user_identity/__init__.py
@@ -1,0 +1,217 @@
+"""
+用户身份工具模块
+
+提供 Agent 查询当前用户身份和权限的能力：
+- GetUserInfoTool: 获取当前用户基本信息（姓名、邮箱、角色等）
+- GetUserPermissionsTool: 获取当前用户角色和权限详情
+"""
+
+from typing import Any, Dict, List, Optional
+
+from ...base import ToolBase, ToolCategory, ToolRiskLevel, ToolSource
+from ...context import ToolContext
+from ...metadata import ToolMetadata
+from ...result import ToolResult
+
+
+def _extract_user_context(context) -> Optional[Dict[str, Any]]:
+    """从工具执行上下文中提取 user_context。
+
+    context 可能是 ToolContext 实例，也可能是普通 dict（来自 ToolAction._execute_tool）。
+    """
+    if context is None:
+        return None
+    if isinstance(context, dict):
+        return context.get("user_context")
+    return getattr(context, "user_context", None)
+
+
+class GetUserInfoTool(ToolBase):
+    """获取当前用户基本信息工具"""
+
+    def _define_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="get_user_info",
+            display_name="Get User Info",
+            description=(
+                "获取当前用户的基本身份信息，包括用户名、邮箱、角色和头像。"
+                "当用户询问'我是谁'、'我的信息是什么'、'告诉我关于我自己'等问题时，"
+                "调用此工具获取当前用户的身份信息。\n\n"
+                "无需任何参数，直接调用即可返回当前登录用户的信息。"
+                "如果用户管理系统未启用，将返回提示信息。"
+            ),
+            category=ToolCategory.UTILITY,
+            risk_level=ToolRiskLevel.SAFE,
+            source=ToolSource.SYSTEM,
+            requires_permission=False,
+            tags=["user", "identity", "info", "user-info"],
+        )
+
+    def _define_parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    async def execute(
+        self, args: Dict[str, Any], context: Optional[ToolContext] = None
+    ) -> ToolResult:
+        user_ctx = _extract_user_context(context)
+
+        if not user_ctx:
+            return ToolResult.ok(
+                output="用户管理未启用，无法获取当前用户信息。",
+                tool_name=self.name,
+            )
+
+        rbac_enabled = user_ctx.get("rbac_enabled", True)
+        name = user_ctx.get("name") or user_ctx.get("user_id", "未知")
+        email = user_ctx.get("email")
+        avatar_url = user_ctx.get("avatar_url")
+        roles = user_ctx.get("roles", [])
+
+        lines = [f"当前用户：{name}"]
+        if roles:
+            lines.append(f"角色：{', '.join(roles)}")
+        else:
+            role = user_ctx.get("role", "未知")
+            lines.append(f"角色：{role}")
+
+        if email:
+            lines.append(f"邮箱：{email}")
+        else:
+            lines.append("邮箱：未设置")
+
+        if avatar_url:
+            lines.append(f"头像：{avatar_url}")
+        else:
+            lines.append("头像：未设置")
+
+        if not rbac_enabled:
+            lines.append("\n（用户管理系统未启用，当前为管理员模式）")
+
+        return ToolResult.ok(
+            output="\n".join(lines),
+            tool_name=self.name,
+        )
+
+
+class GetUserPermissionsTool(ToolBase):
+    """获取当前用户权限详情工具"""
+
+    # 资源类型的中文名称映射
+    RESOURCE_TYPE_NAMES: Dict[str, str] = {
+        "agent": "Agent 应用",
+        "tool": "工具",
+        "knowledge": "知识库",
+        "model": "模型",
+        "system": "系统管理",
+    }
+
+    # 操作的中文名称映射
+    ACTION_NAMES: Dict[str, str] = {
+        "read": "查看",
+        "chat": "对话",
+        "write": "编辑",
+        "execute": "执行",
+        "admin": "管理",
+        "delete": "删除",
+        "create": "创建",
+        "update": "更新",
+    }
+
+    def _define_metadata(self) -> ToolMetadata:
+        return ToolMetadata(
+            name="get_user_permissions",
+            display_name="Get User Permissions",
+            description=(
+                "获取当前用户的角色和权限详情，包括拥有的角色、各资源的操作权限，"
+                "以及不能执行的操作。"
+                "当用户询问'我能做什么'、'我的权限是什么'、'我可以使用什么'等问题时，"
+                "调用此工具获取权限信息。\n\n"
+                "无需任何参数，直接调用即可。"
+                "如果用户管理系统未启用，将返回管理员模式提示。"
+            ),
+            category=ToolCategory.UTILITY,
+            risk_level=ToolRiskLevel.SAFE,
+            source=ToolSource.SYSTEM,
+            requires_permission=False,
+            tags=["user", "permissions", "rbac", "auth"],
+        )
+
+    def _define_parameters(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+
+    async def execute(
+        self, args: Dict[str, Any], context: Optional[ToolContext] = None
+    ) -> ToolResult:
+        user_ctx = _extract_user_context(context)
+
+        if not user_ctx:
+            return ToolResult.ok(
+                output="用户管理未启用，当前拥有全部权限（管理员模式）。",
+                tool_name=self.name,
+            )
+
+        rbac_enabled = user_ctx.get("rbac_enabled", True)
+
+        if not rbac_enabled:
+            name = user_ctx.get("name") or user_ctx.get("user_id", "未知")
+            return ToolResult.ok(
+                output=(
+                    f"当前用户：{name}\n"
+                    f"角色：管理员（RBAC 未启用）\n"
+                    f"权限：拥有全部权限（管理员模式）"
+                ),
+                tool_name=self.name,
+            )
+
+        name = user_ctx.get("name") or user_ctx.get("user_id", "未知")
+        roles = user_ctx.get("roles", [])
+        permissions_map = user_ctx.get("permissions_map", {})
+
+        lines = [f"当前用户：{name}"]
+
+        # 角色信息
+        if roles:
+            lines.append(f"角色：{', '.join(roles)}")
+        else:
+            lines.append("角色：未分配")
+
+        # 权限详情
+        if permissions_map:
+            lines.append("")
+            lines.append("权限详情：")
+            for resource_type, actions in permissions_map.items():
+                resource_name = self.RESOURCE_TYPE_NAMES.get(
+                    resource_type, resource_type
+                )
+                action_names = [
+                    self.ACTION_NAMES.get(a, a) for a in actions
+                ]
+                lines.append(f"  - {resource_name}：{', '.join(action_names)}")
+        else:
+            lines.append("")
+            lines.append("权限：未分配任何权限")
+
+        # 权限摘要（如果有）
+        permissions_summary = user_ctx.get("permissions_summary")
+        if permissions_summary:
+            lines.append("")
+            lines.append(f"权限摘要：{permissions_summary}")
+
+        return ToolResult.ok(
+            output="\n".join(lines),
+            tool_name=self.name,
+        )
+
+
+def register_user_identity_tools(registry: Any) -> None:
+    """注册用户身份工具到统一框架"""
+    registry.register(GetUserInfoTool(), source=ToolSource.SYSTEM)
+    registry.register(GetUserPermissionsTool(), source=ToolSource.SYSTEM)

--- a/packages/derisk-core/src/derisk/agent/tools/context.py
+++ b/packages/derisk-core/src/derisk/agent/tools/context.py
@@ -43,6 +43,7 @@ class ToolContext(BaseModel):
     user_id: Optional[str] = Field(None, description="用户ID")
     user_name: Optional[str] = Field(None, description="用户名")
     user_permissions: List[str] = Field(default_factory=list, description="用户权限")
+    user_context: Optional[Dict[str, Any]] = Field(None, description="用户上下文信息（身份、角色、权限等）")
     
     working_directory: str = Field(".", description="工作目录")
     environment_variables: Dict[str, str] = Field(default_factory=dict, description="环境变量")

--- a/packages/derisk-core/src/derisk/agent/tools/tool_manager.py
+++ b/packages/derisk-core/src/derisk/agent/tools/tool_manager.py
@@ -129,6 +129,8 @@ class ToolManager:
     # 核心必选工具（无论是否沙箱都注入）
     BUILTIN_CORE_TOOLS: List[str] = [
         "ask_user",  # 用户交互（HIL）
+        "get_user_info",  # 获取当前用户身份信息
+        "get_user_permissions",  # 获取当前用户权限详情
     ]
 
     # 基础文件和Shell工具（沙箱和本地共享，默认绑定）

--- a/packages/derisk-serve/src/derisk_serve/utils/auth.py
+++ b/packages/derisk-serve/src/derisk_serve/utils/auth.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import Header, HTTPException, Request
 
@@ -136,3 +136,72 @@ def get_user_from_headers(
     except Exception as e:
         logging.exception("Authentication failed!")
         raise HTTPException(status_code=401, detail=f"Authentication failed: {str(e)}")
+
+
+def format_permissions_summary(
+    permissions: Optional[Dict[str, List[str]]], rbac_enabled: bool
+) -> str:
+    """将权限映射格式化为人类可读的摘要字符串。
+
+    Args:
+        permissions: 资源类型到操作列表的映射，如 {"agent": ["read", "chat"]}
+        rbac_enabled: RBAC 是否启用
+
+    Returns:
+        格式化的权限摘要字符串
+    """
+    if not rbac_enabled:
+        return "全部权限 (RBAC 未启用)"
+
+    if not permissions:
+        return "none"
+
+    parts = []
+    for resource_type, actions in permissions.items():
+        if actions:
+            parts.append(f"{resource_type}: {', '.join(actions)}")
+
+    return "; ".join(parts) if parts else "none"
+
+
+def build_user_context(
+    user_request: UserRequest, rbac_enabled: bool
+) -> Dict[str, Any]:
+    """从 UserRequest 构建用户上下文字典，用于注入到 AgentContext.extra 中。
+
+    Args:
+        user_request: 当前请求的用户信息
+        rbac_enabled: RBAC 权限插件是否启用
+
+    Returns:
+        用户上下文字典，包含 user_id, name, email, avatar_url, role,
+        roles, permissions_map, permissions_summary, rbac_enabled
+    """
+    name = user_request.real_name or user_request.nick_name or user_request.user_id or "未知"
+
+    if not rbac_enabled:
+        return {
+            "user_id": user_request.user_id or "001",
+            "name": name,
+            "email": None,
+            "avatar_url": None,
+            "role": user_request.role or "admin",
+            "roles": [user_request.role or "admin"],
+            "permissions_map": None,
+            "permissions_summary": format_permissions_summary(None, rbac_enabled=False),
+            "rbac_enabled": False,
+        }
+
+    return {
+        "user_id": user_request.user_id or "",
+        "name": name,
+        "email": user_request.email,
+        "avatar_url": user_request.avatar_url,
+        "role": user_request.role or "normal",
+        "roles": user_request.roles or [user_request.role or "normal"],
+        "permissions_map": user_request.permissions,
+        "permissions_summary": format_permissions_summary(
+            user_request.permissions, rbac_enabled=True
+        ),
+        "rbac_enabled": True,
+    }

--- a/tests/test_build_user_context.py
+++ b/tests/test_build_user_context.py
@@ -1,0 +1,147 @@
+"""Tests for build_user_context and format_permissions_summary in auth.py."""
+
+import pytest
+
+from derisk_serve.utils.auth import UserRequest, build_user_context, format_permissions_summary
+
+
+# === format_permissions_summary Tests ===
+
+
+def test_format_permissions_summary_rbac_disabled():
+    result = format_permissions_summary(None, rbac_enabled=False)
+    assert result == "全部权限 (RBAC 未启用)"
+
+
+def test_format_permissions_summary_empty_permissions():
+    result = format_permissions_summary({}, rbac_enabled=True)
+    assert result == "none"
+
+
+def test_format_permissions_summary_none_permissions():
+    result = format_permissions_summary(None, rbac_enabled=True)
+    assert result == "none"
+
+
+def test_format_permissions_summary_single_resource():
+    result = format_permissions_summary(
+        {"agent": ["read", "chat"]}, rbac_enabled=True
+    )
+    assert result == "agent: read, chat"
+
+
+def test_format_permissions_summary_multiple_resources():
+    result = format_permissions_summary(
+        {"agent": ["read", "chat"], "knowledge": ["read"], "tool": ["execute"]},
+        rbac_enabled=True,
+    )
+    assert "agent: read, chat" in result
+    assert "knowledge: read" in result
+    assert "tool: execute" in result
+
+
+def test_format_permissions_summary_empty_actions():
+    result = format_permissions_summary(
+        {"agent": []}, rbac_enabled=True
+    )
+    # Empty actions list should be skipped
+    assert result == "none"
+
+
+# === build_user_context Tests ===
+
+
+def test_build_user_context_full_rbac():
+    user = UserRequest(
+        user_id="3",
+        real_name="Alice",
+        email="alice@example.com",
+        avatar_url="https://example.com/avatar.png",
+        role="editor",
+        roles=["editor"],
+        permissions={"agent": ["read", "chat"], "knowledge": ["read"]},
+    )
+    result = build_user_context(user, rbac_enabled=True)
+
+    assert result["user_id"] == "3"
+    assert result["name"] == "Alice"
+    assert result["email"] == "alice@example.com"
+    assert result["avatar_url"] == "https://example.com/avatar.png"
+    assert result["role"] == "editor"
+    assert result["roles"] == ["editor"]
+    assert result["permissions_map"] == {"agent": ["read", "chat"], "knowledge": ["read"]}
+    assert "agent: read, chat" in result["permissions_summary"]
+    assert result["rbac_enabled"] is True
+
+
+def test_build_user_context_rbac_disabled():
+    user = UserRequest(
+        user_id="001",
+        nick_name="derisk",
+        role="admin",
+    )
+    result = build_user_context(user, rbac_enabled=False)
+
+    assert result["user_id"] == "001"
+    assert result["name"] == "derisk"
+    assert result["email"] is None
+    assert result["avatar_url"] is None
+    assert result["role"] == "admin"
+    assert result["roles"] == ["admin"]
+    assert result["permissions_map"] is None
+    assert result["permissions_summary"] == "全部权限 (RBAC 未启用)"
+    assert result["rbac_enabled"] is False
+
+
+def test_build_user_context_name_fallback():
+    # real_name takes priority over nick_name
+    user = UserRequest(user_id="5", nick_name="Bob", real_name="Robert")
+    result = build_user_context(user, rbac_enabled=True)
+    assert result["name"] == "Robert"
+
+    # Falls back to nick_name when real_name is None
+    user2 = UserRequest(user_id="5", nick_name="Bob")
+    result2 = build_user_context(user2, rbac_enabled=True)
+    assert result2["name"] == "Bob"
+
+    # Falls back to user_id when both are None
+    user3 = UserRequest(user_id="5")
+    result3 = build_user_context(user3, rbac_enabled=True)
+    assert result3["name"] == "5"
+
+
+def test_build_user_context_no_permissions():
+    user = UserRequest(user_id="10", real_name="Viewer", role="viewer")
+    result = build_user_context(user, rbac_enabled=True)
+
+    assert result["role"] == "viewer"
+    assert result["roles"] == ["viewer"]  # Falls back to [role]
+    assert result["permissions_map"] is None
+    assert result["permissions_summary"] == "none"
+
+
+# === ToolContext user_context field Tests ===
+
+
+def test_tool_context_user_context_default():
+    from derisk.agent.tools.context import ToolContext
+
+    ctx = ToolContext()
+    assert ctx.user_context is None
+
+
+def test_tool_context_user_context_set():
+    from derisk.agent.tools.context import ToolContext
+
+    user_ctx = {"user_id": "3", "name": "Alice", "role": "editor"}
+    ctx = ToolContext(user_context=user_ctx)
+    assert ctx.user_context == user_ctx
+
+
+def test_tool_context_user_context_in_dict():
+    from derisk.agent.tools.context import ToolContext
+
+    user_ctx = {"user_id": "3", "name": "Alice", "role": "editor"}
+    ctx = ToolContext(user_context=user_ctx)
+    d = ctx.to_dict()
+    assert d["user_context"] == user_ctx

--- a/tests/test_user_identity_tools.py
+++ b/tests/test_user_identity_tools.py
@@ -1,0 +1,252 @@
+"""Tests for user identity tools (get_user_info, get_user_permissions)."""
+
+import pytest
+
+from derisk.agent.tools.builtin.user_identity import (
+    GetUserInfoTool,
+    GetUserPermissionsTool,
+    _extract_user_context,
+)
+from derisk.agent.tools.context import ToolContext
+
+
+@pytest.fixture
+def user_info_tool():
+    return GetUserInfoTool()
+
+
+@pytest.fixture
+def user_permissions_tool():
+    return GetUserPermissionsTool()
+
+
+@pytest.fixture
+def full_user_context():
+    return {
+        "user_id": "3",
+        "name": "Alice",
+        "email": "alice@example.com",
+        "avatar_url": "https://example.com/avatar.png",
+        "role": "editor",
+        "roles": ["editor"],
+        "permissions_map": {"agent": ["read", "chat"], "knowledge": ["read"]},
+        "permissions_summary": "agent: read, chat; knowledge: read",
+        "rbac_enabled": True,
+    }
+
+
+@pytest.fixture
+def partial_user_context():
+    return {
+        "user_id": "5",
+        "name": "Bob",
+        "email": None,
+        "avatar_url": None,
+        "role": "viewer",
+        "roles": ["viewer"],
+        "permissions_map": {"agent": ["read"]},
+        "permissions_summary": "agent: read",
+        "rbac_enabled": True,
+    }
+
+
+@pytest.fixture
+def rbac_disabled_context():
+    return {
+        "user_id": "001",
+        "name": "derisk",
+        "email": None,
+        "avatar_url": None,
+        "role": "admin",
+        "roles": ["admin"],
+        "permissions_map": None,
+        "permissions_summary": "全部权限 (RBAC 未启用)",
+        "rbac_enabled": False,
+    }
+
+
+# === GetUserInfoTool Tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_full_context(user_info_tool, full_user_context):
+    context = ToolContext(user_id="3", user_context=full_user_context)
+    result = await user_info_tool.execute({}, context)
+    assert result.success is True
+    assert "Alice" in result.output
+    assert "editor" in result.output
+    assert "alice@example.com" in result.output
+    assert "https://example.com/avatar.png" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_partial_context(user_info_tool, partial_user_context):
+    context = ToolContext(user_id="5", user_context=partial_user_context)
+    result = await user_info_tool.execute({}, context)
+    assert result.success is True
+    assert "Bob" in result.output
+    assert "viewer" in result.output
+    assert "未设置" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_no_context(user_info_tool):
+    context = ToolContext(user_id="3")
+    result = await user_info_tool.execute({}, context)
+    assert result.success is True
+    assert "用户管理未启用" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_none_context(user_info_tool):
+    result = await user_info_tool.execute({}, None)
+    assert result.success is True
+    assert "用户管理未启用" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_rbac_disabled(user_info_tool, rbac_disabled_context):
+    context = ToolContext(user_id="001", user_context=rbac_disabled_context)
+    result = await user_info_tool.execute({}, context)
+    assert result.success is True
+    assert "derisk" in result.output
+    assert "管理员模式" in result.output or "未启用" in result.output
+
+
+# === GetUserPermissionsTool Tests ===
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_full_context(
+    user_permissions_tool, full_user_context
+):
+    context = ToolContext(user_id="3", user_context=full_user_context)
+    result = await user_permissions_tool.execute({}, context)
+    assert result.success is True
+    assert "editor" in result.output
+    assert "Agent 应用" in result.output
+    assert "查看" in result.output
+    assert "对话" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_limited(
+    user_permissions_tool, partial_user_context
+):
+    context = ToolContext(user_id="5", user_context=partial_user_context)
+    result = await user_permissions_tool.execute({}, context)
+    assert result.success is True
+    assert "viewer" in result.output
+    assert "Agent 应用" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_no_context(user_permissions_tool):
+    context = ToolContext(user_id="3")
+    result = await user_permissions_tool.execute({}, context)
+    assert result.success is True
+    assert "管理员模式" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_none_context(user_permissions_tool):
+    result = await user_permissions_tool.execute({}, None)
+    assert result.success is True
+    assert "管理员模式" in result.output or "全部权限" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_rbac_disabled(
+    user_permissions_tool, rbac_disabled_context
+):
+    context = ToolContext(user_id="001", user_context=rbac_disabled_context)
+    result = await user_permissions_tool.execute({}, context)
+    assert result.success is True
+    assert "管理员" in result.output
+    assert "RBAC 未启用" in result.output or "全部权限" in result.output
+
+
+# === Tool Metadata Tests ===
+
+
+def test_get_user_info_metadata(user_info_tool):
+    meta = user_info_tool.metadata
+    assert meta.name == "get_user_info"
+    assert meta.category == "utility"
+    assert meta.risk_level == "safe"
+    assert meta.requires_permission is False
+
+
+def test_get_user_permissions_metadata(user_permissions_tool):
+    meta = user_permissions_tool.metadata
+    assert meta.name == "get_user_permissions"
+    assert meta.category == "utility"
+    assert meta.risk_level == "safe"
+    assert meta.requires_permission is False
+
+
+def test_get_user_info_no_required_params(user_info_tool):
+    params = user_info_tool._define_parameters()
+    assert params["type"] == "object"
+    assert params.get("required", []) == []
+
+
+def test_get_user_permissions_no_required_params(user_permissions_tool):
+    params = user_permissions_tool._define_parameters()
+    assert params["type"] == "object"
+    assert params.get("required", []) == []
+
+
+# === _extract_user_context Tests ===
+
+
+def test_extract_user_context_from_tool_context(full_user_context):
+    ctx = ToolContext(user_context=full_user_context)
+    result = _extract_user_context(ctx)
+    assert result == full_user_context
+
+
+def test_extract_user_context_from_dict(full_user_context):
+    ctx = {"user_context": full_user_context, "sandbox_manager": None}
+    result = _extract_user_context(ctx)
+    assert result == full_user_context
+
+
+def test_extract_user_context_from_none():
+    result = _extract_user_context(None)
+    assert result is None
+
+
+def test_extract_user_context_from_empty_dict():
+    result = _extract_user_context({})
+    assert result is None
+
+
+def test_extract_user_context_from_tool_context_without_user_context():
+    ctx = ToolContext(user_id="3")
+    result = _extract_user_context(ctx)
+    assert result is None
+
+
+# === Dict context integration Tests (simulates ToolAction._execute_tool flow) ===
+
+
+@pytest.mark.asyncio
+async def test_get_user_info_with_dict_context(user_info_tool, full_user_context):
+    """Simulate the actual execution path where context is a plain dict."""
+    context_dict = {"user_context": full_user_context}
+    result = await user_info_tool.execute({}, context_dict)
+    assert result.success is True
+    assert "Alice" in result.output
+    assert "editor" in result.output
+
+
+@pytest.mark.asyncio
+async def test_get_user_permissions_with_dict_context(
+    user_permissions_tool, full_user_context
+):
+    """Simulate the actual execution path where context is a plain dict."""
+    context_dict = {"user_context": full_user_context}
+    result = await user_permissions_tool.execute({}, context_dict)
+    assert result.success is True
+    assert "editor" in result.output

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -87,7 +87,9 @@ function LayoutWrapper({ children }: { children: React.ReactNode }) {
       authCheckInProgress.current = true;
       try {
         const oauthStatus = await authService.getOAuthStatus();
-        if (!oauthStatus.enabled) {
+        const needsLogin = oauthStatus.enabled || oauthStatus.local_login_enabled;
+
+        if (!needsLogin) {
           const user = { user_channel: "derisk", user_no: "001", nick_name: "derisk" };
           localStorage.setItem(STORAGE_USERINFO_KEY, JSON.stringify(user));
           localStorage.setItem(STORAGE_USERINFO_VALID_TIME_KEY, Date.now().toString());
@@ -107,8 +109,7 @@ function LayoutWrapper({ children }: { children: React.ReactNode }) {
       } catch {
         try {
           const oauthStatus = await authService.getOAuthStatus();
-          if (oauthStatus.enabled) {
-            // 避免已经在登录页面时重复跳转
+          if (oauthStatus.enabled || oauthStatus.local_login_enabled) {
             const currentPath = window.location.pathname;
             if (!currentPath.startsWith("/login") && !currentPath.startsWith("/auth/callback")) {
               window.location.href = "/login";

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { authService } from '@/services/auth';
-import { GithubOutlined, LoginOutlined, ThunderboltOutlined } from '@ant-design/icons';
-import { Alert, Button, Card, Spin } from 'antd';
-import { useSearchParams } from 'next/navigation';
+import { GithubOutlined, LoginOutlined, ThunderboltOutlined, UserOutlined, LockOutlined } from '@ant-design/icons';
+import { Alert, Button, Card, Divider, Form, Input, Spin } from 'antd';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -17,15 +17,19 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 export default function LoginPage() {
   const [loading, setLoading] = useState(true);
+  const [loginLoading, setLoginLoading] = useState(false);
   const [providers, setProviders] = useState<Array<{ id: string; type: string }>>([]);
   const [oauthEnabled, setOauthEnabled] = useState(false);
+  const [localLoginEnabled, setLocalLoginEnabled] = useState(false);
+  const [loginError, setLoginError] = useState('');
   const loadedRef = useRef(false);
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const [form] = Form.useForm();
   const errorCode = searchParams?.get('error') || '';
   const errorMsg = errorCode ? ERROR_MESSAGES[errorCode] || `登录出错：${errorCode}` : '';
 
   useEffect(() => {
-    // 防止重复加载
     if (loadedRef.current) return;
     loadedRef.current = true;
     loadOAuthStatus();
@@ -37,11 +41,12 @@ export default function LoginPage() {
       const status = await authService.getOAuthStatus();
       setOauthEnabled(status.enabled);
       setProviders(status.providers || []);
+      setLocalLoginEnabled(status.local_login_enabled ?? false);
     } catch (error: any) {
-      // 静默处理错误，避免触发刷新循环
       console.error('获取登录配置失败:', error);
       setOauthEnabled(false);
       setProviders([]);
+      setLocalLoginEnabled(false);
     } finally {
       setLoading(false);
     }
@@ -52,6 +57,33 @@ export default function LoginPage() {
     window.location.href = url;
   };
 
+  const handleLocalLogin = async (values: { username: string; password: string }) => {
+    setLoginLoading(true);
+    setLoginError('');
+    try {
+      const data = await authService.localLogin(values.username, values.password);
+      // Store token and user info
+      if (data.token) {
+        localStorage.setItem('__db_gpt_tk_key', data.token);
+      }
+      const userInfo = {
+        user_channel: 'local',
+        user_no: data.user_no || String(data.user?.id || ''),
+        nick_name: data.nick_name || data.user?.name || '',
+        avatar_url: data.avatar_url || '',
+        email: data.email || '',
+        role: data.role || 'normal',
+      };
+      localStorage.setItem('__db_gpt_uinfo_key', JSON.stringify(userInfo));
+      router.replace('/');
+    } catch (error: any) {
+      const msg = error?.response?.data?.detail || '登录失败，请检查用户名和密码';
+      setLoginError(msg);
+    } finally {
+      setLoginLoading(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className='flex items-center justify-center min-h-screen bg-gray-50'>
@@ -60,7 +92,7 @@ export default function LoginPage() {
     );
   }
 
-  if (!oauthEnabled || providers.length === 0) {
+  if (!oauthEnabled && !localLoginEnabled) {
     return (
       <div className='flex items-center justify-center min-h-screen bg-gray-50'>
         <Card title='登录' style={{ width: 400 }}>
@@ -73,34 +105,58 @@ export default function LoginPage() {
   return (
     <div className='flex items-center justify-center min-h-screen bg-gray-50'>
       <Card title='登录' style={{ width: 400 }}>
-        {errorMsg && (
+        {(errorMsg || loginError) && (
           <Alert
-            type={errorCode === 'user_disabled' ? 'error' : 'warning'}
-            message={errorMsg}
+            type='error'
+            message={errorMsg || loginError}
             showIcon
             className='mb-4'
           />
         )}
-        <p className='mb-4 text-gray-600'>请选择登录方式</p>
-        <div className='space-y-3'>
-          {providers.map(p => {
-            const getIcon = () => {
-              if (p.type === 'github') return <GithubOutlined />;
-              if (p.type === 'alibaba-inc') return <ThunderboltOutlined className='text-orange-500' />;
-              return <LoginOutlined />;
-            };
-            const getLabel = () => {
-              if (p.type === 'github') return '使用 GitHub 登录';
-              if (p.type === 'alibaba-inc') return '使用 alibaba-inc 登录';
-              return `使用 ${p.id} 登录`;
-            };
-            return (
-              <Button key={p.id} type='primary' block size='large' icon={getIcon()} onClick={() => handleLogin(p.id)}>
-                {getLabel()}
-              </Button>
-            );
-          })}
-        </div>
+
+        {localLoginEnabled && (
+          <>
+            <Form form={form} onFinish={handleLocalLogin} layout='vertical'>
+              <Form.Item name='username' rules={[{ required: true, message: '请输入用户名' }]}>
+                <Input prefix={<UserOutlined />} placeholder='用户名' size='large' />
+              </Form.Item>
+              <Form.Item name='password' rules={[{ required: true, message: '请输入密码' }]}>
+                <Input.Password prefix={<LockOutlined />} placeholder='密码' size='large' />
+              </Form.Item>
+              <Form.Item>
+                <Button type='primary' htmlType='submit' block size='large' loading={loginLoading}>
+                  登录
+                </Button>
+              </Form.Item>
+            </Form>
+
+            {oauthEnabled && providers.length > 0 && (
+              <Divider>或</Divider>
+            )}
+          </>
+        )}
+
+        {oauthEnabled && providers.length > 0 && (
+          <div className='space-y-3'>
+            {providers.map(p => {
+              const getIcon = () => {
+                if (p.type === 'github') return <GithubOutlined />;
+                if (p.type === 'alibaba-inc') return <ThunderboltOutlined className='text-orange-500' />;
+                return <LoginOutlined />;
+              };
+              const getLabel = () => {
+                if (p.type === 'github') return '使用 GitHub 登录';
+                if (p.type === 'alibaba-inc') return '使用 alibaba-inc 登录';
+                return `使用 ${p.id} 登录`;
+              };
+              return (
+                <Button key={p.id} block size='large' icon={getIcon()} onClick={() => handleLogin(p.id)}>
+                  {getLabel()}
+                </Button>
+              );
+            })}
+          </div>
+        )}
       </Card>
     </div>
   );

--- a/web/src/components/permissions/UserManagement.tsx
+++ b/web/src/components/permissions/UserManagement.tsx
@@ -188,11 +188,28 @@ export default function UserManagement({ roles: externalRoles }: UserManagementP
     }
   };
 
-  const handleToggleRole = async (user: UnifiedUserRow) => {
-    const nextRole = user.legacy_role === 'admin' ? 'normal' : 'admin';
+  const handleToggleAdmin = async (user: UnifiedUserRow) => {
+    const isAdmin = user.roles.includes('admin');
     try {
-      await usersService.updateUser(user.id, { role: nextRole });
-      message.success(nextRole === 'admin' ? t('permissions_set_admin') : t('permissions_unset_admin'));
+      if (isAdmin) {
+        // Remove admin RBAC role
+        const adminRole = allRoles.find((r) => r.name === 'admin');
+        if (adminRole) {
+          await permissionsService.batchRemoveRoles(user.id, [adminRole.id]);
+        }
+        // Also set legacy role to normal
+        await usersService.updateUser(user.id, { role: 'normal' });
+        message.success(t('permissions_unset_admin'));
+      } else {
+        // Assign admin RBAC role
+        const adminRole = allRoles.find((r) => r.name === 'admin');
+        if (adminRole) {
+          await permissionsService.batchAssignRoles(user.id, [adminRole.id]);
+        }
+        // Also set legacy role to admin (for checker.py bypass compatibility)
+        await usersService.updateUser(user.id, { role: 'admin' });
+        message.success(t('permissions_set_admin'));
+      }
       await loadUsers({ silent: true });
     } catch (e: unknown) {
       message.error(t('permissions_operation_failed') + ': ' + (e as Error).message);
@@ -307,17 +324,6 @@ export default function UserManagement({ roles: externalRoles }: UserManagementP
         render: (provider: string) => (provider ? <Tag>{provider}</Tag> : <Text type="secondary">-</Text>),
       },
       {
-        title: t('permissions_legacy_role'),
-        dataIndex: 'legacy_role',
-        key: 'legacy_role',
-        width: 120,
-        render: (role: string) => (
-          <Tag color={role === 'admin' ? 'gold' : 'default'}>
-            {role === 'admin' ? t('permissions_admin_user') : t('permissions_normal_user')}
-          </Tag>
-        ),
-      },
-      {
         title: t('permissions_col_status'),
         dataIndex: 'is_active',
         key: 'is_active',
@@ -383,10 +389,10 @@ export default function UserManagement({ roles: externalRoles }: UserManagementP
             <Button type="link" size="small" onClick={() => openUserDetail(record.id)}>
               {t('permissions_add_authorization')}
             </Button>
-            <Button type="link" size="small" onClick={() => handleToggleRole(record)}>
-              {record.legacy_role === 'admin' ? t('permissions_unset_admin') : t('permissions_set_admin')}
+            <Button type="link" size="small" onClick={() => handleToggleAdmin(record)}>
+              {record.roles.includes('admin') ? t('permissions_unset_admin') : t('permissions_set_admin')}
             </Button>
-            {currentUser?.role === 'admin' && currentUser?.id !== record.id && (
+            {currentUser?.role === 'admin' && record.id !== currentUser.id && (
               <Popconfirm
                 title={t('permissions_delete_user_confirm')}
                 onConfirm={() => handleDelete(record)}

--- a/web/src/services/auth.ts
+++ b/web/src/services/auth.ts
@@ -6,6 +6,7 @@ const API_BASE = '/api/v1';
 export interface OAuthStatus {
   enabled: boolean;
   providers: Array<{ id: string; type: string }>;
+  local_login_enabled?: boolean;
 }
 
 export interface AuthUser {
@@ -76,6 +77,11 @@ class AuthService {
 
   async logout(): Promise<void> {
     await axios.post(`${API_BASE}/auth/logout`);
+  }
+
+  async localLogin(username: string, password: string): Promise<MeResponse & { token?: string }> {
+    const response = await axios.post(`${API_BASE}/auth/login`, { username, password });
+    return response.data.data;
   }
 
   getOAuthLoginUrl(provider: string): string {


### PR DESCRIPTION
# Description
 
                                                                                                                                                                                                                                       本次合并包含三项功能改进：                                           
                                         
1. Agent 支持识别当前用户身份与权限 
新增内置工具 get_user_info 和 get_user_permissions，Agent 可按需感知对话用户的身份和权限。用户询问"我是谁"时返回基本信息，询问"我能做什么"时返回角色与权限详情。采用 Tool 方式实现（非 System Prompt 注入），按需调用、零模板侵入，RBAC
未启用时自动降级为管理员模式。                                                                                                                                                                                                        
   
2. TOML 模型配置自动同步                                                                                                                                                                                         
修复 TOML 配置的模型提供者在重启后不生效的问题。当 derisk.json 的 providers 为空时自动从 TOML bootstrap；进一步重构为 TOML 有 providers 时始终同步到 JSON，确保修改配置后重启即可生效，无需手动清理。同时修正了模型 ID 大小写、补充了热门模型列表。           

 3. OAuth2 用户 RBAC 同步修复 + 本地登录  
修复 OAuth2 登录后用户无 RBAC 角色导致无权限的系列问题：新老用户登录时均自动分配角色、启动时为存量用户补分配角色、读接口权限从 admin 降为认证即可。新增本地账密登录（bcrypt），前端支持账密登录表单。统一账号角色与 RBAC
角色的同步逻辑，修复 MySQL 不自动同步新增列的问题。                     
# How Has This Been Tested? 

# Snapshots:

<img width="3312" height="1216" alt="image" src="https://github.com/user-attachments/assets/9e67c2d0-2794-4b66-833f-0cd89f7fd52c" />
<img width="3250" height="1698" alt="image" src="https://github.com/user-attachments/assets/9714071a-2806-42b3-94ed-d6f70aa0d14b" />



Include snapshots for easier review.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have already rebased the commits and make the commit message conform to the project standard.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
